### PR TITLE
Add UI reference and handoff prompt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@v4
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@v6
+              uses: pnpm/action-setup@v4
 
             - name: Setup Node
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@v4
               with:
                   node-version: 22
                   cache: pnpm

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
         timeout-minutes: 360
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@v4
 
             - name: Initialize CodeQL
               uses: github/codeql-action/init@v4

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ Start here when opening the repo.
 - [Architecture](architecture.md) - expected system shape
 - [Every Code Integration](every-code-integration.md) - how this talks to Every Code
 - [Repository Settings](repo-settings.md) - GitHub, CI, Dependabot, branch protection
+- [UI References](ui-reference.md) - mature products and systems to use as UX references
 - [Code Style](style/coding-standards.md) - project-wide style rules
 - [TypeScript Style](style/typescript.md) - TypeScript and React rules
 - [Testing Style](style/testing.md) - test expectations

--- a/docs/decisions/0001-product-foundation.md
+++ b/docs/decisions/0001-product-foundation.md
@@ -14,11 +14,12 @@ The product will use existing UI frameworks and patterns instead of asking the o
 
 The existing Discord DUI proves the product need and the protocol shape: sessions, turns, approvals, requested input, replies, and session controls. Discord is useful as a bridge, but it cannot provide the first-class Apple client, notification behavior, or structured operator interface we want.
 
-T3 Code and similar tools are valuable references, but Every Code is the runtime and should remain the source of truth.
+T3 Code and similar tools are valuable domain references, but Every Code is the runtime and should remain the source of truth. Mature products such as Linear, Sentry, GitHub Actions, Raycast, and Apple platform guidance should carry more weight for UI/UX quality.
 
 ## Consequences
 
 - Build around Every Code's protocol and session model.
 - Treat T3 Code-style UX as reference material, not a mandatory fork.
+- Use `docs/ui-reference.md` before visually significant UI work.
 - Keep iOS, iPadOS, and macOS in the product design from the start.
 - Defer deployment/CD decisions until the first client and host model are clearer.

--- a/docs/ui-reference.md
+++ b/docs/ui-reference.md
@@ -1,0 +1,151 @@
+# UI References
+
+## Purpose
+
+Code Everywhere should not depend on the operator or this harness inventing UI/UX from scratch. Use mature product references, real screenshots, and established component systems.
+
+The product should feel like a calm operator cockpit for Every Code sessions, not a terminal emulator, generic AI chat app, or marketing dashboard.
+
+## Reference Hierarchy
+
+### North Star: Linear
+
+Use Linear as the primary product-quality reference.
+
+Why it matters:
+
+- dense but calm workspace
+- left navigation with clear state groupings
+- focused detail surfaces
+- triage/inbox mental model
+- keyboard-friendly actions
+- clear status transitions
+- mobile and desktop versions that still feel like the same product
+
+Map this to Code Everywhere as:
+
+- session list instead of issue list
+- attention queue instead of triage inbox
+- active session detail instead of issue detail
+- status and pending work instead of issue workflow state
+
+### Operational Detail: Sentry
+
+Use Sentry as the reference for detail pages where something needs attention.
+
+Why it matters:
+
+- high-signal issue headers
+- main diagnostic content
+- metadata and actions in a side rail
+- activity/history that supports decisions
+- clear distinction between urgent state and supporting context
+
+Map this to Code Everywhere as:
+
+- blocked session detail
+- approval/requested-input detail
+- error and disconnection detail
+- session metadata, host, cwd, branch, turn, and epoch context
+
+### Timeline And Logs: GitHub Actions
+
+Use GitHub Actions as the reference for expandable timelines, run state, logs, and artifacts.
+
+Why it matters:
+
+- workflow status is visible at a glance
+- steps can be expanded only when needed
+- failure context is easy to find
+- artifacts and logs are related to the run rather than floating elsewhere
+
+Map this to Code Everywhere as:
+
+- turn timeline
+- tool/action steps
+- summaries and expandable details
+- command output as supporting detail, not the primary UI
+
+### Fast Actions: Raycast
+
+Use Raycast as the reference for command palette and quick action ergonomics.
+
+Why it matters:
+
+- action names are clear
+- keyboard flow is fast
+- search and command execution are unified
+- power features do not crowd the main interface
+
+Map this to Code Everywhere as:
+
+- quick jump to session
+- approve/deny/reply/pause/continue/end actions
+- command palette for frequent operator actions
+
+### Apple Clients: Apple Human Interface Guidelines
+
+Use Apple HIG for iOS, iPadOS, and macOS behavior.
+
+Why it matters:
+
+- notifications are part of the core product loop
+- native navigation, sheets, sidebars, split views, and deep links should feel platform-correct
+- Keychain, APNs, and notification actions need native interaction design
+
+Map this to Code Everywhere as:
+
+- notification actions for approval and requested input where appropriate
+- deep links into exact session/pending item
+- iPad split-view cockpit
+- macOS menu/window behavior when useful
+
+### Visual Research: Real App Screenshots
+
+Use real production app screenshots and pattern libraries such as Mobbin when visual judgment is the hard part.
+
+Why it matters:
+
+- real products reveal spacing, hierarchy, and mobile compromises better than abstract prose
+- production screenshots avoid fantasy-dashboard drift
+- references can be compared directly against our rendered UI
+
+## Domain Reference: T3 Code
+
+T3 Code is a useful domain reference, not the visual north star and not the backend plan.
+
+Study it for:
+
+- agent session sidebar ideas
+- turn timeline and assistant output patterns
+- approval surfaces
+- diff/status presentation
+- coding-agent vocabulary
+
+Do not copy:
+
+- Codex app-server dependency assumptions
+- provider lifecycle assumptions
+- desktop-only product assumptions
+- visual direction when stronger product references apply
+
+## Implementation System
+
+Use established UI primitives before custom design:
+
+- React for the initial web cockpit
+- shadcn/ui for component composition and dashboard blocks
+- Radix UI for accessible primitives
+- Tailwind for styling
+- lucide-react for icons
+- Capacitor or SwiftUI when native Apple behavior matters
+
+## Review Rule
+
+For visually significant UI work:
+
+1. Build from these references, not from a blank page.
+2. Review the rendered app in a browser.
+3. Capture screenshots for desktop and narrow/mobile widths.
+4. Compare the screenshots to the reference hierarchy above.
+5. If visual judgment is the hard part, hand the rendered state to an outside Claude/Codex GUI app session for design iteration.

--- a/handoff.md
+++ b/handoff.md
@@ -1,0 +1,64 @@
+# Burn After Reading
+
+This file is a temporary handoff prompt for the next session. Read it once, create a durable plan in `docs/` or the repository's planning location, then delete `handoff.md` in the same first change.
+
+Do not preserve this file as project documentation. Its job is to transfer context into the first implementation session and then disappear.
+
+## First Prompt
+
+Read `AGENTS.md` and the docs under `docs/`, especially:
+
+- `docs/product-goals.md`
+- `docs/architecture.md`
+- `docs/every-code-integration.md`
+- `docs/ui-reference.md`
+- `docs/style/ui-ux.md`
+- `docs/style/typescript.md`
+- `docs/style/testing.md`
+
+Then create a durable implementation plan for the first Code Everywhere spike and commit it somewhere permanent, such as `docs/plans/first-cockpit-spike.md`.
+
+After the plan exists, delete this `handoff.md` file.
+
+The first spike should build a fake-data structured cockpit for Every Code sessions. Do not build a terminal stream. The cockpit should show:
+
+- session list with running, idle, blocked, waiting-for-input, waiting-for-approval, ended, and error states
+- active session detail
+- turn timeline
+- pending approval surface
+- requested-input form surface
+- reply, pause, continue, status, and end controls
+- enough fake protocol-shaped data to exercise the UI states
+
+Use the current Every Code references:
+
+- local Every Code fork: `../code`
+- Every Code fork remote: `https://github.com/cbusillo/code`
+- Discord DUI bridge reference: `../discord-blue/discord_blue/doodads/every_code`
+- Discord DUI tests: `../discord-blue/tests/test_every_code.py`
+
+Use the UI reference hierarchy in `docs/ui-reference.md`:
+
+- Linear for the main cockpit and triage model
+- Sentry for blocked/error/session detail pages
+- GitHub Actions for turn timelines, expandable steps, and artifacts/logs
+- Raycast for command palette and quick actions
+- Apple HIG for iOS/iPadOS/macOS behavior and notifications
+- T3 Code only as a domain reference for coding-agent sessions, turns, approvals, and diffs
+
+Implementation direction:
+
+- React + TypeScript
+- shadcn/ui-style composition
+- Radix primitives
+- Tailwind styling
+- lucide-react icons
+- fake data first, live Every Code bridge later
+
+Validation expectations:
+
+- run `pnpm validate`
+- run the app locally if an app is added
+- review in a real browser
+- capture desktop and narrow/mobile screenshots or describe what was checked
+- if the visual design is the hard part, prepare a clear handoff to an outside Claude/Codex GUI app session rather than relying on this harness alone


### PR DESCRIPTION
## Summary
- Add a UI reference hierarchy with Linear, Sentry, GitHub Actions, Raycast, Apple HIG, real app screenshots, shadcn/Radix/Tailwind, and T3 Code as domain reference only.
- Link the UI reference from the docs index and foundation decision.
- Add a temporary root handoff.md with burn-after-reading instructions for the first implementation session.

## Verification
- pnpm validate