### PR TITLE
Complete broker reliability closeout smokes

### DIFF
--- a/docs/every-code-integration.md
+++ b/docs/every-code-integration.md
@@ -105,6 +105,31 @@ real browser, enqueues a status command from the cockpit, stops the broker to
 confirm HTTP fallback, then restarts the broker and verifies live recovery. It
 requires the local `ui-browser` helper.
 
+To verify retained/pruned broker state in the browser, run:
+
+```sh
+pnpm smoke:cockpit:retained-pruned
+```
+
+That smoke seeds a persistent broker with high-volume and stale-epoch events,
+restarts the broker from compacted JSON, verifies the retained projection, opens
+the web cockpit in a browser, checks post-pruning rendering and fallback copy,
+and asserts no horizontal overflow in desktop and constrained-width layouts.
+
+To exercise the local broker and web cockpit with a real trusted Every Code TUI,
+run:
+
+```sh
+pnpm smoke:cockpit:real-tui
+```
+
+That smoke starts a real interactive `code` TUI with Code Everywhere HTTP
+enabled, waits for its `session_hello`, verifies it in the web cockpit, sends a
+status command from the browser, and waits for the TUI to publish the accepted
+command outcome. It requires `code`, `expect`, and `ui-browser` on `PATH`. Set
+`CODE_EVERYWHERE_CODE_BINARY=/absolute/path/to/code` to test a specific local
+Every Code build when multiple `code` binaries are installed.
+
 For the full live Every Code loop:
 
 1. Start the cockpit server with `pnpm cockpit:server`.

--- a/docs/style/testing.md
+++ b/docs/style/testing.md
@@ -18,6 +18,8 @@ High-value areas:
 - Test: `pnpm test`
 - Broker projection smoke: `pnpm smoke:cockpit:turns`
 - Browser-backed broker/web smoke: `pnpm smoke:cockpit:web`
+- Retained/pruned browser smoke: `pnpm smoke:cockpit:retained-pruned`
+- Real TUI broker/web smoke: `pnpm smoke:cockpit:real-tui`
 - Full gate: `pnpm validate`
 
 ## Style

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
         "format:check": "prettier --check .",
         "lint": "eslint .",
         "lint:dry-run": "eslint . --fix-dry-run",
+        "smoke:cockpit:real-tui": "node scripts/smoke-cockpit-real-tui-live-loop.mjs",
+        "smoke:cockpit:retained-pruned": "node scripts/smoke-cockpit-retained-pruned-browser.mjs",
         "smoke:cockpit:turns": "node scripts/smoke-cockpit-turn-lifecycle.mjs",
         "smoke:cockpit:web": "node scripts/smoke-cockpit-web-live-loop.mjs",
         "typecheck": "pnpm --recursive typecheck",

--- a/packages/server/src/persistence.test.ts
+++ b/packages/server/src/persistence.test.ts
@@ -1,4 +1,7 @@
 import { randomUUID } from "node:crypto"
+import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
 
 import { describe, expect, it } from "vitest"
 
@@ -143,6 +146,89 @@ describe("cockpit persistence wrapper", () => {
         expect(replayedState.pendingApprovals["approval-1"]).toEqual(baseApproval)
         expect(replayedState.turns["turn-1"]?.steps.map((candidate) => candidate.id)).toEqual(["step-3", "approval:approval-1"])
     })
+
+    it("replays reconnect state while preserving stale evidence and command outcomes", async () => {
+        const directory = await mkdtemp(join(tmpdir(), "code-everywhere-persistence-"))
+        const filePath = join(directory, "broker.json")
+
+        try {
+            const stores = createPersistentCockpitStores(filePath, {
+                eventRetentionPolicy: {
+                    maxEndedSessions: 0,
+                    maxTurnsPerSession: 1,
+                    maxStepsPerTurn: 3,
+                    maxCommandOutcomes: 5,
+                    maxStaleEvents: 5,
+                },
+            })
+
+            stores.store.ingest({
+                kind: "session_hello",
+                session: baseSession,
+            })
+            stores.commandStore.enqueue(baseCommand)
+            const claim = stores.commandStore.claimUndelivered({ sessionId: "session-1" })
+            stores.store.ingest({
+                kind: "session_hello",
+                session: {
+                    ...baseSession,
+                    sessionEpoch: "epoch-2",
+                    updatedAt: "2026-04-27T16:10:00.000Z",
+                },
+            })
+            stores.store.ingest(commandOutcome(claim.commands[0]?.id ?? "command-1", "epoch-1", "2026-04-27T16:11:00.000Z"))
+
+            const reconnectedStores = createPersistentCockpitStores(filePath, {
+                eventRetentionPolicy: {
+                    maxEndedSessions: 0,
+                    maxTurnsPerSession: 1,
+                    maxStepsPerTurn: 3,
+                    maxCommandOutcomes: 5,
+                    maxStaleEvents: 5,
+                },
+            })
+            const replayedSnapshot = reconnectedStores.store.getSnapshot()
+
+            expect(replayedSnapshot.sessions[0]).toMatchObject({
+                sessionId: "session-1",
+                sessionEpoch: "epoch-2",
+            })
+            expect(replayedSnapshot.state.staleEvents).toEqual([
+                {
+                    eventKind: "command_outcome",
+                    sessionId: "session-1",
+                    eventEpoch: "epoch-1",
+                    currentEpoch: "epoch-2",
+                    receivedAt: "2026-04-27T16:11:00.000Z",
+                },
+            ])
+            expect(reconnectedStores.commandStore.getCommands()[0]).toMatchObject({
+                id: claim.commands[0]?.id,
+            })
+            expect(reconnectedStores.commandStore.getCommands()[0]?.deliveredAt).not.toBeNull()
+
+            reconnectedStores.store.ingest(commandOutcome("command-2", "epoch-2", "2026-04-27T16:12:00.000Z"))
+
+            const finalSnapshot = createPersistentCockpitStores(filePath, {
+                eventRetentionPolicy: {
+                    maxEndedSessions: 0,
+                    maxTurnsPerSession: 1,
+                    maxStepsPerTurn: 3,
+                    maxCommandOutcomes: 5,
+                    maxStaleEvents: 5,
+                },
+            }).store.getSnapshot()
+            const persisted = JSON.parse(await readFile(filePath, "utf8")) as { events: CockpitProjectionEvent[] }
+
+            expect(finalSnapshot.state.commandOutcomes["command-2"]).toMatchObject({
+                sessionEpoch: "epoch-2",
+                status: "accepted",
+            })
+            expect(projectCockpitEvents(persisted.events).sessions["session-1"]?.sessionEpoch).toBe("epoch-2")
+        } finally {
+            await rm(directory, { recursive: true, force: true })
+        }
+    })
 })
 
 const unusedPath = (): string => `/tmp/code-everywhere-unused-${String(process.pid)}-${randomUUID()}.json`
@@ -166,4 +252,17 @@ const step = (id: string): TurnStep => ({
     detail: "pnpm test",
     timestamp: `2026-04-27T16:02:0${id.charAt(id.length - 1)}.000Z`,
     state: "completed",
+})
+
+const commandOutcome = (commandId: string, sessionEpoch: string, handledAt: string): CockpitProjectionEvent => ({
+    kind: "command_outcome",
+    outcome: {
+        commandId,
+        sessionId: "session-1",
+        sessionEpoch,
+        commandKind: "status_request",
+        status: "accepted",
+        reason: null,
+        handledAt,
+    },
 })

--- a/scripts/smoke-cockpit-real-tui-live-loop.mjs
+++ b/scripts/smoke-cockpit-real-tui-live-loop.mjs
@@ -1,0 +1,324 @@
+#!/usr/bin/env node
+
+import { mkdir, mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { spawn } from "node:child_process"
+import { createServer } from "node:net"
+import { exit, kill as killProcess, platform, stderr, stdout } from "node:process"
+import { setTimeout as delay } from "node:timers/promises"
+
+const smokePollIntervalMs = 500
+const processLogs = new WeakMap()
+
+const run = async () => {
+    const uiBrowser = await findCommand("ui-browser", "ui-browser is required for pnpm smoke:cockpit:real-tui")
+    const configuredCodeBinary = process.env.CODE_EVERYWHERE_CODE_BINARY?.trim()
+    const codeBinary =
+        configuredCodeBinary !== undefined && configuredCodeBinary !== ""
+            ? configuredCodeBinary
+            : await findCommand("code", "code is required for pnpm smoke:cockpit:real-tui")
+    const expectBinary = await findCommand("expect", "expect is required for pnpm smoke:cockpit:real-tui")
+    const session = `cockpit-real-tui-smoke-${String(process.pid)}-${String(Date.now())}`
+    const directory = await mkdtemp(join(tmpdir(), "code-everywhere-real-tui-smoke-"))
+    const workdir = join(directory, "work")
+    const brokerPort = await getFreePort()
+    const webPort = await getFreePort()
+    const brokerUrl = `http://127.0.0.1:${String(brokerPort)}`
+    const webUrl = `http://127.0.0.1:${String(webPort)}`
+    let broker = null
+    let web = null
+    let tui = null
+
+    try {
+        await mkdir(workdir, { recursive: true })
+        broker = startBroker(brokerPort)
+        await waitForHttp(`${brokerUrl}/snapshot`, "cockpit broker")
+        web = startWeb(webPort, brokerUrl)
+        await waitForHttp(webUrl, "web cockpit")
+
+        tui = startCodeTui(expectBinary, codeBinary, brokerUrl, workdir)
+        const tuiSession = await waitForTuiSession(brokerUrl)
+
+        await ui(uiBrowser, session, ["open", webUrl, "1000"])
+        await ui(uiBrowser, session, ["wait-for", "text=Connected to Code Everywhere.", "15000"])
+        await assertBrowserState(uiBrowser, session, {
+            mode: "Live HTTP",
+            hostLabel: "Smoke TUI",
+            summary: "Connected to Code Everywhere.",
+            sessionId: tuiSession.sessionId,
+        })
+
+        await clickFirstStatusButton(uiBrowser, session)
+        const outcome = await waitForCommandOutcome(brokerUrl, "status_request")
+        assertEqual(outcome.status, "accepted", "status command outcome")
+        assertEqual(outcome.sessionId, tuiSession.sessionId, "status command session")
+        assertEqual(outcome.sessionEpoch, tuiSession.sessionEpoch, "status command epoch")
+
+        await stopProcess(broker)
+        broker = null
+        await ui(uiBrowser, session, ["wait-for", "text=HTTP fallback", "10000"])
+        broker = startBroker(brokerPort)
+        await waitForHttp(`${brokerUrl}/snapshot`, "restarted cockpit broker")
+        const replayedSession = await waitForTuiSession(brokerUrl)
+        assertEqual(replayedSession.sessionId, tuiSession.sessionId, "replayed TUI session id")
+        assertEqual(replayedSession.sessionEpoch, tuiSession.sessionEpoch, "replayed TUI session epoch")
+        await ui(uiBrowser, session, ["wait-for", "text=Connected to Code Everywhere.", "15000"])
+        await assertBrowserState(uiBrowser, session, {
+            mode: "Live HTTP",
+            hostLabel: "Smoke TUI",
+            summary: "Connected to Code Everywhere.",
+            sessionId: tuiSession.sessionId,
+        })
+
+        stdout.write(
+            `Cockpit real TUI live-loop smoke passed at ${webUrl} using broker ${brokerUrl} and session ${tuiSession.sessionId}\n`,
+        )
+    } catch (error) {
+        stderr.write(`${error instanceof Error ? error.message : "Cockpit real TUI live-loop smoke failed"}\n`)
+        if (broker !== null) {
+            writeProcessLogs("Broker", broker)
+        }
+        if (web !== null) {
+            writeProcessLogs("Web", web)
+        }
+        if (tui !== null) {
+            writeProcessLogs("TUI", tui)
+        }
+        exit(1)
+    } finally {
+        await ui(uiBrowser, session, ["close"]).catch(() => undefined)
+        if (tui !== null) {
+            await stopProcess(tui)
+        }
+        if (web !== null) {
+            await stopProcess(web)
+        }
+        if (broker !== null) {
+            await stopProcess(broker)
+        }
+        await rm(directory, { recursive: true, force: true })
+    }
+}
+
+const startCodeTui = (expectBinary, codeBinary, brokerUrl, workdir) => {
+    const script = `
+set code_binary ${tclQuote(codeBinary)}
+set broker_url ${tclQuote(brokerUrl)}
+set host_label ${tclQuote("Smoke TUI")}
+set workdir ${tclQuote(workdir)}
+set timeout 45
+spawn $code_binary -c remote_inbox.enabled=true -c remote_inbox.code_everywhere_url=$broker_url -c remote_inbox.host_label=$host_label -C $workdir
+after 45000
+send "\\003"
+after 500
+send "\\003"
+expect eof
+`
+    return trackProcessLogs(
+        spawn(expectBinary, ["-c", script], {
+            detached: platform !== "win32",
+            stdio: ["ignore", "pipe", "pipe"],
+        }),
+    )
+}
+
+const tclQuote = (value) => `"${String(value).replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`
+
+const waitForTuiSession = async (brokerUrl) => {
+    const startedAt = Date.now()
+    while (Date.now() - startedAt < 20000) {
+        const snapshot = await getJson(`${brokerUrl}/snapshot`)
+        const session = snapshot.sessions.find((candidate) => candidate.hostLabel === "Smoke TUI")
+        if (session !== undefined) {
+            return session
+        }
+        await delay(250)
+    }
+    throw new Error("Timed out waiting for real TUI session hello")
+}
+
+const waitForCommandOutcome = async (brokerUrl, commandKind) => {
+    const startedAt = Date.now()
+    while (Date.now() - startedAt < 20000) {
+        const snapshot = await getJson(`${brokerUrl}/snapshot`)
+        const outcome = Object.values(snapshot.state.commandOutcomes).find((candidate) => candidate.commandKind === commandKind)
+        if (outcome !== undefined) {
+            return outcome
+        }
+        await delay(250)
+    }
+    throw new Error(`Timed out waiting for ${commandKind} command outcome from real TUI`)
+}
+
+const findCommand = async (command, errorMessage) => {
+    try {
+        return await runCommand("sh", ["-lc", `command -v ${command}`])
+    } catch {
+        throw new Error(errorMessage)
+    }
+}
+
+const startBroker = (port) =>
+    trackProcessLogs(
+        spawn("pnpm", ["--filter", "@code-everywhere/server", "start", "--", "--memory", "--port", String(port)], {
+            detached: platform !== "win32",
+            stdio: ["ignore", "pipe", "pipe"],
+        }),
+    )
+
+const startWeb = (port, brokerUrl) =>
+    trackProcessLogs(
+        spawn(
+            "pnpm",
+            ["--filter", "@code-everywhere/web", "exec", "vite", "--host", "127.0.0.1", "--port", String(port), "--strictPort"],
+            {
+                detached: platform !== "win32",
+                env: {
+                    ...process.env,
+                    VITE_COCKPIT_HTTP_URL: brokerUrl,
+                    VITE_COCKPIT_POLL_INTERVAL_MS: String(smokePollIntervalMs),
+                },
+                stdio: ["ignore", "pipe", "pipe"],
+            },
+        ),
+    )
+
+const trackProcessLogs = (child) => {
+    processLogs.set(child, "")
+    child.stdout.on("data", (chunk) => processLogs.set(child, `${processLogs.get(child) ?? ""}${String(chunk)}`))
+    child.stderr.on("data", (chunk) => processLogs.set(child, `${processLogs.get(child) ?? ""}${String(chunk)}`))
+    return child
+}
+
+const writeProcessLogs = (label, child) => {
+    const logs = String(processLogs.get(child) ?? "").trim()
+    if (logs !== "") {
+        stderr.write(`\n${label} output:\n${logs}\n`)
+    }
+}
+
+const stopProcess = async (child) => {
+    if (child.exitCode !== null) {
+        return
+    }
+    signalProcess(child, "SIGTERM")
+    const closed = await waitForClose(child, 3000)
+    if (!closed) {
+        signalProcess(child, "SIGKILL")
+        await waitForClose(child, 3000)
+    }
+}
+
+const signalProcess = (child, signal) => {
+    if (child.pid === undefined) {
+        return
+    }
+    try {
+        if (platform === "win32") {
+            child.kill(signal)
+        } else {
+            killProcess(-child.pid, signal)
+        }
+    } catch {
+        child.kill(signal)
+    }
+}
+
+const waitForClose = async (child, timeoutMs) => {
+    if (child.exitCode !== null) {
+        return true
+    }
+    return Promise.race([new Promise((resolve) => child.once("close", () => resolve(true))), delay(timeoutMs).then(() => false)])
+}
+
+const getFreePort = async () =>
+    new Promise((resolve, reject) => {
+        const server = createServer()
+        server.once("error", reject)
+        server.listen(0, "127.0.0.1", () => {
+            const address = server.address()
+            const port = typeof address === "object" && address !== null ? address.port : null
+            server.close(() => (port === null ? reject(new Error("Unable to reserve a local port")) : resolve(port)))
+        })
+    })
+
+const waitForHttp = async (url, label) => {
+    const startedAt = Date.now()
+    let lastError = null
+    while (Date.now() - startedAt < 30000) {
+        try {
+            const response = await globalThis.fetch(url, { cache: "no-store" })
+            if (response.ok) {
+                return
+            }
+            lastError = new Error(`${label} returned ${String(response.status)}`)
+        } catch (error) {
+            lastError = error
+        }
+        await delay(100)
+    }
+    throw new Error(`Timed out waiting for ${label}: ${lastError instanceof Error ? lastError.message : "not ready"}`)
+}
+
+const getJson = async (url) => {
+    const response = await globalThis.fetch(url, { headers: { accept: "application/json" } })
+    if (!response.ok) {
+        throw new Error(`GET ${url} failed with ${String(response.status)}`)
+    }
+    return response.json()
+}
+
+const ui = async (uiBrowser, session, args) => runCommand(uiBrowser, ["--session", session, ...args])
+
+const assertBrowserState = async (uiBrowser, session, expected) => {
+    const raw = await ui(uiBrowser, session, [
+        "eval",
+        "(() => ({ text: document.body.innerText, canScrollX: document.documentElement.scrollWidth > document.documentElement.clientWidth }))()",
+    ])
+    const state = JSON.parse(raw)
+    for (const [label, value] of Object.entries(expected)) {
+        if (!state.text.includes(value)) {
+            throw new Error(`Expected browser text to include ${label} ${JSON.stringify(value)}`)
+        }
+    }
+    if (state.canScrollX) {
+        throw new Error("Expected real TUI cockpit smoke to avoid horizontal overflow")
+    }
+}
+
+const clickFirstStatusButton = async (uiBrowser, session) => {
+    await ui(uiBrowser, session, [
+        "eval",
+        "(() => { const button = Array.from(document.querySelectorAll('button')).find((candidate) => candidate.innerText.trim() === 'Status'); if (!button) throw new Error('Status button not found'); button.click(); return true; })()",
+    ])
+}
+
+const assertEqual = (actual, expected, label) => {
+    if (actual !== expected) {
+        throw new Error(`Expected ${label} to be ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+}
+
+const runCommand = async (command, args) =>
+    new Promise((resolve, reject) => {
+        const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] })
+        let output = ""
+        let errorOutput = ""
+        child.stdout.on("data", (chunk) => {
+            output += String(chunk)
+        })
+        child.stderr.on("data", (chunk) => {
+            errorOutput += String(chunk)
+        })
+        child.once("error", reject)
+        child.once("close", (code) => {
+            if (code === 0) {
+                resolve(output.trim())
+                return
+            }
+            reject(new Error(`${command} ${args.join(" ")} failed with code ${String(code)}\n${errorOutput.trim()}`))
+        })
+    })
+
+await run()

--- a/scripts/smoke-cockpit-retained-pruned-browser.mjs
+++ b/scripts/smoke-cockpit-retained-pruned-browser.mjs
@@ -1,0 +1,426 @@
+#!/usr/bin/env node
+
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { spawn } from "node:child_process"
+import { createServer } from "node:net"
+import { exit, kill as killProcess, platform, stderr, stdout } from "node:process"
+import { setTimeout as delay } from "node:timers/promises"
+
+const smokePollIntervalMs = 500
+const processLogs = new WeakMap()
+
+const run = async () => {
+    const uiBrowser = await findUiBrowser()
+    const session = `cockpit-pruned-smoke-${String(process.pid)}-${String(Date.now())}`
+    const directory = await mkdtemp(join(tmpdir(), "code-everywhere-pruned-smoke-"))
+    const dataFile = join(directory, "broker.json")
+    const brokerPort = await getFreePort()
+    const webPort = await getFreePort()
+    const brokerUrl = `http://127.0.0.1:${String(brokerPort)}`
+    const webUrl = `http://127.0.0.1:${String(webPort)}`
+    let broker = null
+    let web = null
+
+    try {
+        broker = startBroker(brokerPort, dataFile)
+        await waitForHttp(`${brokerUrl}/snapshot`, "cockpit broker")
+        await postJson(`${brokerUrl}/events`, { events: createPruningEvents() })
+        await stopProcess(broker)
+        broker = null
+
+        broker = startBroker(brokerPort, dataFile)
+        await waitForHttp(`${brokerUrl}/snapshot`, "restarted cockpit broker")
+        const snapshot = await getJson(`${brokerUrl}/snapshot`)
+        assertRetainedSnapshot(snapshot)
+
+        web = startWeb(webPort, brokerUrl)
+        await waitForHttp(webUrl, "web cockpit")
+        await ui(uiBrowser, session, ["open", webUrl, "1000"])
+        await ui(uiBrowser, session, ["wait-for", "text=Active pruning smoke session", "10000"])
+        await selectSession(uiBrowser, session, "Active pruning smoke session")
+        await ui(uiBrowser, session, ["wait-for", "text=Newest retained step with a long token", "10000"])
+        await assertBrowserState(uiBrowser, session, {
+            mode: "Live HTTP",
+            active: "Active pruning smoke session",
+            retainedEnded: "Recently completed pruning smoke session",
+            detail: "Newest retained step with a long token",
+        })
+        await assertBrowserExcludes(uiBrowser, session, ["Old completed pruning smoke session 0"])
+        await assertConstrainedLayout(uiBrowser, session, 390)
+
+        await stopProcess(broker)
+        broker = null
+        await ui(uiBrowser, session, ["wait-for", "text=HTTP fallback", "10000"])
+        await assertBrowserState(uiBrowser, session, {
+            mode: "HTTP fallback",
+            active: "Active pruning smoke session",
+            retainedEnded: "Recently completed pruning smoke session",
+        })
+
+        stdout.write(`Cockpit retained/pruned browser smoke passed at ${webUrl} using broker ${brokerUrl}\n`)
+    } catch (error) {
+        stderr.write(`${error instanceof Error ? error.message : "Cockpit retained/pruned browser smoke failed"}\n`)
+        if (broker !== null) {
+            writeProcessLogs("Broker", broker)
+        }
+        if (web !== null) {
+            writeProcessLogs("Web", web)
+        }
+        exit(1)
+    } finally {
+        await ui(uiBrowser, session, ["close"]).catch(() => undefined)
+        if (web !== null) {
+            await stopProcess(web)
+        }
+        if (broker !== null) {
+            await stopProcess(broker)
+        }
+        await rm(directory, { recursive: true, force: true })
+    }
+}
+
+const assertRetainedSnapshot = (snapshot) => {
+    const sessionIds = snapshot.sessions.map((session) => session.sessionId).sort()
+    if (!sessionIds.includes("active-pruned") || !sessionIds.includes("ended-new") || sessionIds.includes("ended-old-0")) {
+        throw new Error(`Unexpected retained session ids ${JSON.stringify(sessionIds)}`)
+    }
+    assertEqual(snapshot.state.turns["active-turn"]?.steps.length, 100, "active retained step count")
+    assertEqual(snapshot.state.turns["active-turn"]?.steps.at(-1)?.id, "active-step-119", "newest retained step")
+    assertEqual(snapshot.state.staleEvents.length, 1, "stale event evidence count")
+    assertEqual(snapshot.state.staleEvents[0]?.eventKind, "turn_step_added", "stale event kind")
+}
+
+const assertEqual = (actual, expected, label) => {
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+        throw new Error(`Expected ${label} to be ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+}
+
+const createPruningEvents = () => [
+    ...Array.from({ length: 11 }, (_value, index) =>
+        endedSessionEvents(
+            `ended-old-${String(index)}`,
+            `Old completed pruning smoke session ${String(index)}`,
+            `2026-04-28T10:${String(index).padStart(2, "0")}:00.000Z`,
+        ),
+    ).flat(),
+    ...endedSessionEvents("ended-new", "Recently completed pruning smoke session", "2026-04-28T11:00:00.000Z"),
+    {
+        kind: "session_hello",
+        session: session(
+            "active-pruned",
+            "epoch-1",
+            "Active pruning smoke session",
+            "idle",
+            "active-turn",
+            "2026-04-28T12:00:00.000Z",
+        ),
+    },
+    {
+        kind: "session_hello",
+        session: session(
+            "active-pruned",
+            "epoch-2",
+            "Active pruning smoke session",
+            "idle",
+            "active-turn",
+            "2026-04-28T12:10:00.000Z",
+        ),
+    },
+    {
+        kind: "turn_started",
+        sessionEpoch: "epoch-2",
+        turn: {
+            id: "active-turn",
+            sessionId: "active-pruned",
+            title: "Retained pruning smoke turn",
+            status: "running",
+            actor: "assistant",
+            startedAt: "2026-04-28T12:01:00.000Z",
+            completedAt: null,
+            summary: "High-volume turn with retained newest step.",
+            steps: Array.from({ length: 120 }, (_value, index) => ({
+                id: `active-step-${String(index)}`,
+                kind: "tool",
+                title: "Shell command",
+                detail:
+                    index === 119
+                        ? "Newest retained step with a long token pruned-browser-smoke-token-that-must-wrap-without-overflow"
+                        : `Pruned older step ${String(index)}`,
+                timestamp: activeStepTimestamp(index),
+                state: "completed",
+            })),
+        },
+    },
+    {
+        kind: "turn_step_added",
+        sessionId: "active-pruned",
+        sessionEpoch: "epoch-1",
+        turnId: "active-turn",
+        step: {
+            id: "stale-step",
+            kind: "tool",
+            title: "Stale shell command",
+            detail: "This stale event should be retained as bounded evidence.",
+            timestamp: "2026-04-28T12:11:00.000Z",
+            state: "error",
+        },
+    },
+]
+
+const endedSessionEvents = (sessionId, summary, updatedAt) => [
+    {
+        kind: "session_hello",
+        session: session(sessionId, "epoch-1", summary, "idle", `${sessionId}-turn`, updatedAt),
+    },
+    {
+        kind: "turn_started",
+        sessionEpoch: "epoch-1",
+        turn: {
+            id: `${sessionId}-turn`,
+            sessionId,
+            title: summary,
+            status: "completed",
+            actor: "assistant",
+            startedAt: updatedAt,
+            completedAt: updatedAt,
+            summary,
+            steps: [
+                {
+                    id: `${sessionId}-step`,
+                    kind: "message",
+                    title: "Assistant message",
+                    detail: summary,
+                    timestamp: updatedAt,
+                    state: "completed",
+                },
+            ],
+        },
+    },
+    {
+        kind: "session_status_changed",
+        sessionId,
+        sessionEpoch: "epoch-1",
+        status: "ended",
+        summary,
+        updatedAt,
+    },
+]
+
+const session = (sessionId, sessionEpoch, summary, status, currentTurnId, updatedAt) => ({
+    sessionId,
+    sessionEpoch,
+    hostLabel: "Smoke Host",
+    cwd: "/tmp/code-everywhere-pruned-smoke",
+    branch: "main",
+    pid: 4242,
+    model: "code",
+    status,
+    summary,
+    startedAt: updatedAt,
+    updatedAt,
+    currentTurnId,
+})
+
+const activeStepTimestamp = (index) =>
+    `2026-04-28T12:${String(2 + Math.floor(index / 60)).padStart(2, "0")}:${String(index % 60).padStart(2, "0")}.000Z`
+
+const findUiBrowser = async () => {
+    try {
+        return await runCommand("sh", ["-lc", "command -v ui-browser"])
+    } catch {
+        throw new Error("ui-browser is required for pnpm smoke:cockpit:retained-pruned")
+    }
+}
+
+const startBroker = (port, dataFile) =>
+    trackProcessLogs(
+        spawn("pnpm", ["--filter", "@code-everywhere/server", "start", "--", "--data-file", dataFile, "--port", String(port)], {
+            detached: platform !== "win32",
+            stdio: ["ignore", "pipe", "pipe"],
+        }),
+    )
+
+const startWeb = (port, brokerUrl) =>
+    trackProcessLogs(
+        spawn(
+            "pnpm",
+            ["--filter", "@code-everywhere/web", "exec", "vite", "--host", "127.0.0.1", "--port", String(port), "--strictPort"],
+            {
+                detached: platform !== "win32",
+                env: {
+                    ...process.env,
+                    VITE_COCKPIT_HTTP_URL: brokerUrl,
+                    VITE_COCKPIT_POLL_INTERVAL_MS: String(smokePollIntervalMs),
+                },
+                stdio: ["ignore", "pipe", "pipe"],
+            },
+        ),
+    )
+
+const trackProcessLogs = (child) => {
+    processLogs.set(child, "")
+    child.stdout.on("data", (chunk) => processLogs.set(child, `${processLogs.get(child) ?? ""}${String(chunk)}`))
+    child.stderr.on("data", (chunk) => processLogs.set(child, `${processLogs.get(child) ?? ""}${String(chunk)}`))
+    return child
+}
+
+const writeProcessLogs = (label, child) => {
+    const logs = String(processLogs.get(child) ?? "").trim()
+    if (logs !== "") {
+        stderr.write(`\n${label} output:\n${logs}\n`)
+    }
+}
+
+const stopProcess = async (child) => {
+    if (child.exitCode !== null) {
+        return
+    }
+    signalProcess(child, "SIGTERM")
+    const closed = await waitForClose(child, 3000)
+    if (!closed) {
+        signalProcess(child, "SIGKILL")
+        await waitForClose(child, 3000)
+    }
+}
+
+const signalProcess = (child, signal) => {
+    if (child.pid === undefined) {
+        return
+    }
+    try {
+        if (platform === "win32") {
+            child.kill(signal)
+        } else {
+            killProcess(-child.pid, signal)
+        }
+    } catch {
+        child.kill(signal)
+    }
+}
+
+const waitForClose = async (child, timeoutMs) => {
+    if (child.exitCode !== null) {
+        return true
+    }
+    return Promise.race([new Promise((resolve) => child.once("close", () => resolve(true))), delay(timeoutMs).then(() => false)])
+}
+
+const getFreePort = async () =>
+    new Promise((resolve, reject) => {
+        const server = createServer()
+        server.once("error", reject)
+        server.listen(0, "127.0.0.1", () => {
+            const address = server.address()
+            const port = typeof address === "object" && address !== null ? address.port : null
+            server.close(() => (port === null ? reject(new Error("Unable to reserve a local port")) : resolve(port)))
+        })
+    })
+
+const waitForHttp = async (url, label) => {
+    const startedAt = Date.now()
+    let lastError = null
+    while (Date.now() - startedAt < 30000) {
+        try {
+            const response = await globalThis.fetch(url, { cache: "no-store" })
+            if (response.ok) {
+                return
+            }
+            lastError = new Error(`${label} returned ${String(response.status)}`)
+        } catch (error) {
+            lastError = error
+        }
+        await delay(100)
+    }
+    throw new Error(`Timed out waiting for ${label}: ${lastError instanceof Error ? lastError.message : "not ready"}`)
+}
+
+const postJson = async (url, body) => {
+    const response = await globalThis.fetch(url, {
+        method: "POST",
+        headers: { accept: "application/json", "content-type": "application/json" },
+        body: JSON.stringify(body),
+    })
+    if (!response.ok) {
+        throw new Error(`POST ${url} failed with ${String(response.status)}`)
+    }
+    return response.json()
+}
+
+const getJson = async (url) => {
+    const response = await globalThis.fetch(url, { headers: { accept: "application/json" } })
+    if (!response.ok) {
+        throw new Error(`GET ${url} failed with ${String(response.status)}`)
+    }
+    return response.json()
+}
+
+const ui = async (uiBrowser, session, args) => runCommand(uiBrowser, ["--session", session, ...args])
+
+const selectSession = async (uiBrowser, session, summary) => {
+    await ui(uiBrowser, session, [
+        "eval",
+        `(() => { const button = Array.from(document.querySelectorAll('button')).find((candidate) => candidate.innerText.includes(${JSON.stringify(summary)})); if (!button) throw new Error('Session button not found'); button.click(); return true; })()`,
+    ])
+}
+
+const assertBrowserState = async (uiBrowser, session, expected) => {
+    const raw = await ui(uiBrowser, session, [
+        "eval",
+        "(() => ({ text: document.body.innerText, canScrollX: document.documentElement.scrollWidth > document.documentElement.clientWidth }))()",
+    ])
+    const state = JSON.parse(raw)
+    for (const [label, value] of Object.entries(expected)) {
+        if (!state.text.includes(value)) {
+            throw new Error(`Expected browser text to include ${label} ${JSON.stringify(value)}`)
+        }
+    }
+    if (state.canScrollX) {
+        throw new Error("Expected retained/pruned cockpit to avoid horizontal overflow")
+    }
+}
+
+const assertBrowserExcludes = async (uiBrowser, session, excludedText) => {
+    const text = JSON.parse(await ui(uiBrowser, session, ["eval", "document.body.innerText"]))
+    for (const value of excludedText) {
+        if (text.includes(value)) {
+            throw new Error(`Expected browser text not to include ${JSON.stringify(value)}`)
+        }
+    }
+}
+
+const assertConstrainedLayout = async (uiBrowser, session, width) => {
+    const raw = await ui(uiBrowser, session, [
+        "eval",
+        `(() => { const frame = document.querySelector('.app-frame'); if (!frame) throw new Error('app frame missing'); const previous = frame.getAttribute('style') || ''; frame.style.width = '${String(width)}px'; frame.style.maxWidth = '${String(width)}px'; frame.style.margin = '0'; const overflow = Array.from(document.querySelectorAll('.panel, .session-row, .timeline-step, button')).filter((element) => element.scrollWidth > element.clientWidth + 1).map((element) => element.className || element.tagName).slice(0, 5); const canScrollX = document.documentElement.scrollWidth > document.documentElement.clientWidth; frame.setAttribute('style', previous); return { overflow, canScrollX }; })()`,
+    ])
+    const result = JSON.parse(raw)
+    if (result.canScrollX || result.overflow.length > 0) {
+        throw new Error(`Expected constrained retained/pruned layout without overflow, got ${JSON.stringify(result)}`)
+    }
+}
+
+const runCommand = async (command, args) =>
+    new Promise((resolve, reject) => {
+        const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] })
+        let output = ""
+        let errorOutput = ""
+        child.stdout.on("data", (chunk) => {
+            output += String(chunk)
+        })
+        child.stderr.on("data", (chunk) => {
+            errorOutput += String(chunk)
+        })
+        child.once("error", reject)
+        child.once("close", (code) => {
+            if (code === 0) {
+                resolve(output.trim())
+                return
+            }
+            reject(new Error(`${command} ${args.join(" ")} failed with code ${String(code)}\n${errorOutput.trim()}`))
+        })
+    })
+
+await run()


### PR DESCRIPTION
## Summary
- add a persisted reconnect/stale regression covering replay, delivered commands, stale evidence, and command outcomes
- add retained/pruned browser smoke for compacted JSON replay, high-volume timeline rendering, fallback, and constrained-width overflow
- add real trusted TUI live-loop smoke for broker + web + Every Code command outcome and broker-restart rehello behavior
- document the new smoke commands and `CODE_EVERYWHERE_CODE_BINARY` override for testing a specific local Every Code build

## Validation
- `pnpm lint:dry-run`
- `pnpm validate`
- `pnpm smoke:cockpit:retained-pruned` passed at `http://127.0.0.1:54938` using broker `http://127.0.0.1:54937`
- `CODE_EVERYWHERE_CODE_BINARY=/Users/cbusillo/.code/working/code/branches/broker-reconnect-rehello/.code/working/_target-cache/code/broker-reconnect-rehello-94d784c58851-226e776ea5f7/code-rs/dev-fast/code pnpm smoke:cockpit:real-tui` passed at `http://127.0.0.1:55053` using broker `http://127.0.0.1:55052`, session `9d132f76-7775-4934-a5b0-b8cb272712c9`
- `pnpm smoke:cockpit:web` passed at `http://127.0.0.1:55208` using broker `http://127.0.0.1:55207`
- `pnpm smoke:cockpit:turns` passed at `http://127.0.0.1:55325`
- post-overlay-commit real TUI smoke passed at `http://127.0.0.1:56179` using broker `http://127.0.0.1:56178`, session `d01d1c15-1718-457f-b750-c564ffbbfd08`

## Overlay dependency
- Every Code overlay reconnect fix pushed to `cbusillo/code` `local/cbusillo-overlay` at `78deb85a7aa8df777ddf61d62ec4341dc01292f8`
- Overlay evidence: `cargo test -p code-tui remote_inbox --features test-helpers` passed; clean-worktree `./build-fast.sh` passed with binary hash `3a3b4d0a28cd4dd446d5ced7a883e02ef7cb87bdee035cb195468d7db1309627`; commit hook `./build-fast.sh` passed with binary hash `9fc4749e4895e204175ad174a14b894c6f5a96a53a97ed32cd2d4c8ebea86baa`
