### PR TITLE
Fix cockpit smoke cleanup and poll interval parsing

### DIFF
--- a/apps/web/src/cockpitTransport.test.ts
+++ b/apps/web/src/cockpitTransport.test.ts
@@ -28,6 +28,7 @@ describe("cockpit HTTP transport client", () => {
         expect(normalizePollIntervalMs("500")).toBe(500)
         expect(normalizePollIntervalMs("250.9")).toBe(250)
         expect(normalizePollIntervalMs("0")).toBeNull()
+        expect(normalizePollIntervalMs("0.5")).toBeNull()
         expect(normalizePollIntervalMs("nope")).toBeNull()
     })
 

--- a/apps/web/src/cockpitTransport.ts
+++ b/apps/web/src/cockpitTransport.ts
@@ -232,7 +232,7 @@ export function normalizePollIntervalMs(value: string | undefined): number | nul
     }
 
     const pollIntervalMs = Number(normalized)
-    return Number.isFinite(pollIntervalMs) && pollIntervalMs > 0 ? Math.floor(pollIntervalMs) : null
+    return Number.isFinite(pollIntervalMs) && pollIntervalMs >= 1 ? Math.floor(pollIntervalMs) : null
 }
 
 export const describeTransportStatus = (status: CockpitTransportStatus): string => {

--- a/scripts/smoke-cockpit-real-tui-live-loop.mjs
+++ b/scripts/smoke-cockpit-real-tui-live-loop.mjs
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { spawn } from "node:child_process"
 import { createServer } from "node:net"
-import { exit, kill as killProcess, platform, stderr, stdout } from "node:process"
+import { kill as killProcess, platform, stderr, stdout } from "node:process"
 import { setTimeout as delay } from "node:timers/promises"
 
 const smokePollIntervalMs = 500
@@ -85,7 +85,7 @@ const run = async () => {
         if (tui !== null) {
             writeProcessLogs("TUI", tui)
         }
-        exit(1)
+        process.exitCode = 1
     } finally {
         await ui(uiBrowser, session, ["close"]).catch(() => undefined)
         if (tui !== null) {

--- a/scripts/smoke-cockpit-retained-pruned-browser.mjs
+++ b/scripts/smoke-cockpit-retained-pruned-browser.mjs
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { spawn } from "node:child_process"
 import { createServer } from "node:net"
-import { exit, kill as killProcess, platform, stderr, stdout } from "node:process"
+import { kill as killProcess, platform, stderr, stdout } from "node:process"
 import { setTimeout as delay } from "node:timers/promises"
 
 const smokePollIntervalMs = 500
@@ -68,7 +68,7 @@ const run = async () => {
         if (web !== null) {
             writeProcessLogs("Web", web)
         }
-        exit(1)
+        process.exitCode = 1
     } finally {
         await ui(uiBrowser, session, ["close"]).catch(() => undefined)
         if (web !== null) {

--- a/scripts/smoke-cockpit-turn-lifecycle.mjs
+++ b/scripts/smoke-cockpit-turn-lifecycle.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process"
-import { exit, kill as killProcess, platform, stderr, stdout } from "node:process"
+import { kill as killProcess, platform, stderr, stdout } from "node:process"
 import { setTimeout as delay } from "node:timers/promises"
 
 const serverReadyPattern = /listening at (http:\/\/\S+)/
@@ -45,7 +45,7 @@ const run = async () => {
         if (logs.trim() !== "") {
             stderr.write(`\nServer output:\n${logs}`)
         }
-        exit(1)
+        process.exitCode = 1
     } finally {
         await stopServer(server)
     }

--- a/scripts/smoke-cockpit-web-live-loop.mjs
+++ b/scripts/smoke-cockpit-web-live-loop.mjs
@@ -2,7 +2,7 @@
 
 import { spawn } from "node:child_process"
 import { createServer } from "node:net"
-import { exit, kill as killProcess, platform, stderr, stdout } from "node:process"
+import { kill as killProcess, platform, stderr, stdout } from "node:process"
 import { setTimeout as delay } from "node:timers/promises"
 
 const smokePollIntervalMs = 500
@@ -68,7 +68,7 @@ const run = async () => {
         if (web !== null) {
             writeProcessLogs("Web", web)
         }
-        exit(1)
+        process.exitCode = 1
     } finally {
         await ui(uiBrowser, session, ["close"]).catch(() => undefined)
         if (web !== null) {


### PR DESCRIPTION
## Summary
- let cockpit smoke scripts unwind through `finally` on failures so child broker/web/TUI processes are still cleaned up
- reject sub-millisecond configured poll intervals instead of flooring them to `0`
- add a poll interval regression for `0.5`

## Validation
- `pnpm --filter @code-everywhere/web test -- src/cockpitTransport.test.ts` passed: web suite 4 files, 22 tests
- `pnpm lint:dry-run`
- `pnpm validate`: contracts 13 tests, server 40 tests, web 22 tests
- `pnpm smoke:cockpit:retained-pruned` passed at `http://127.0.0.1:51335` using broker `http://127.0.0.1:51334`
- `pnpm smoke:cockpit:web` passed at `http://127.0.0.1:51487` using broker `http://127.0.0.1:51486`
- `pnpm smoke:cockpit:turns` passed at `http://127.0.0.1:51662`
- `pnpm smoke:cockpit:real-tui` passed at `http://127.0.0.1:51745` using broker `http://127.0.0.1:51744`, session `2022fbba-f588-4eb4-9fbe-1d16d99fadb3`
