### PR TITLE
Cover real TUI command outcomes

### DIFF
--- a/apps/web/src/cockpitCommands.test.ts
+++ b/apps/web/src/cockpitCommands.test.ts
@@ -82,6 +82,71 @@ describe("cockpit command client", () => {
         })
     })
 
+    it("accepts every retained session command shape", async () => {
+        const commands: SessionCommand[] = [
+            {
+                kind: "reply",
+                sessionId: "session-1",
+                sessionEpoch: "epoch-1",
+                content: "Keep going.",
+            },
+            {
+                kind: "continue_autonomously",
+                sessionId: "session-1",
+                sessionEpoch: "epoch-1",
+            },
+            {
+                kind: "pause_current_turn",
+                sessionId: "session-1",
+                sessionEpoch: "epoch-1",
+            },
+            {
+                kind: "end_session",
+                sessionId: "session-1",
+                sessionEpoch: "epoch-1",
+            },
+            {
+                kind: "status_request",
+                sessionId: "session-1",
+                sessionEpoch: "epoch-1",
+            },
+            {
+                kind: "approval_decision",
+                sessionId: "session-1",
+                sessionEpoch: "epoch-1",
+                approvalId: "approval-1",
+                decision: "deny",
+            },
+            {
+                kind: "request_user_input_response",
+                sessionId: "session-1",
+                sessionEpoch: "epoch-1",
+                turnId: "turn-1",
+                answers: [{ questionId: "question-1", value: "timeline" }],
+            },
+        ]
+        const fetchImpl: Parameters<typeof fetchCockpitCommands>[1] = () =>
+            Promise.resolve(
+                new Response(
+                    JSON.stringify({
+                        commandCount: commands.length,
+                        commands: commands.map((retainedCommand, index) => ({
+                            id: `command-${String(index + 1)}`,
+                            receivedAt: "2026-04-27T16:20:00.000Z",
+                            deliveredAt: null,
+                            command: retainedCommand,
+                        })),
+                    }),
+                    { status: 200 },
+                ),
+            )
+
+        await expect(fetchCockpitCommands("http://127.0.0.1:4789", fetchImpl)).resolves.toMatchObject({
+            commandCount: commands.length,
+            commands: commands.map((retainedCommand) => ({ command: retainedCommand })),
+        })
+    })
+
     it("rejects failed or malformed command responses", async () => {
         const failingFetch: Parameters<typeof postCockpitCommand>[2] = () => Promise.resolve(new Response("Nope", { status: 400 }))
         const malformedFetch: Parameters<typeof postCockpitCommand>[2] = () =>

--- a/scripts/smoke-cockpit-real-tui-live-loop.mjs
+++ b/scripts/smoke-cockpit-real-tui-live-loop.mjs
@@ -49,11 +49,17 @@ const run = async () => {
             sessionId: tuiSession.sessionId,
         })
 
-        await clickFirstStatusButton(uiBrowser, session)
+        await clickFirstCommandButton(uiBrowser, session, "Status")
         const outcome = await waitForCommandOutcome(brokerUrl, "status_request")
         assertEqual(outcome.status, "accepted", "status command outcome")
         assertEqual(outcome.sessionId, tuiSession.sessionId, "status command session")
         assertEqual(outcome.sessionEpoch, tuiSession.sessionEpoch, "status command epoch")
+        await clickFirstCommandButton(uiBrowser, session, "Pause")
+        const pauseOutcome = await waitForCommandOutcome(brokerUrl, "pause_current_turn")
+        assertEqual(pauseOutcome.status, "rejected", "idle pause command outcome")
+        assertEqual(pauseOutcome.reason, "no active turn is running", "idle pause rejection reason")
+        assertEqual(pauseOutcome.sessionId, tuiSession.sessionId, "idle pause command session")
+        assertEqual(pauseOutcome.sessionEpoch, tuiSession.sessionEpoch, "idle pause command epoch")
 
         await stopProcess(broker)
         broker = null
@@ -287,10 +293,10 @@ const assertBrowserState = async (uiBrowser, session, expected) => {
     }
 }
 
-const clickFirstStatusButton = async (uiBrowser, session) => {
+const clickFirstCommandButton = async (uiBrowser, session, label) => {
     await ui(uiBrowser, session, [
         "eval",
-        "(() => { const button = Array.from(document.querySelectorAll('button')).find((candidate) => candidate.innerText.trim() === 'Status'); if (!button) throw new Error('Status button not found'); button.click(); return true; })()",
+        `(() => { const label = ${JSON.stringify(label)}; const button = Array.from(document.querySelectorAll('button')).find((candidate) => candidate.innerText.trim() === label); if (!button) throw new Error(label + ' button not found'); button.click(); return true; })()`,
     ])
 }
 

--- a/scripts/smoke-cockpit-web-live-loop.mjs
+++ b/scripts/smoke-cockpit-web-live-loop.mjs
@@ -35,8 +35,12 @@ const run = async () => {
             detail: "Broker/web smoke step complete.",
         })
 
-        await clickFirstStatusButton(uiBrowser, session)
+        await clickFirstCommandButton(uiBrowser, session, "Status")
         await waitForCommand(brokerUrl, "status_request")
+        await clickFirstCommandButton(uiBrowser, session, "Pause")
+        await waitForCommand(brokerUrl, "pause_current_turn")
+        await clickFirstCommandButton(uiBrowser, session, "Continue")
+        await waitForCommand(brokerUrl, "continue_autonomously")
 
         await stopProcess(broker)
         broker = null
@@ -255,10 +259,10 @@ const assertBrowserState = async (uiBrowser, session, expected) => {
     }
 }
 
-const clickFirstStatusButton = async (uiBrowser, session) => {
+const clickFirstCommandButton = async (uiBrowser, session, label) => {
     await ui(uiBrowser, session, [
         "eval",
-        "(() => { const button = Array.from(document.querySelectorAll('button')).find((candidate) => candidate.innerText.trim() === 'Status'); if (!button) throw new Error('Status button not found'); button.click(); return true; })()",
+        `(() => { const label = ${JSON.stringify(label)}; const button = Array.from(document.querySelectorAll('button')).find((candidate) => candidate.innerText.trim() === label); if (!button) throw new Error(label + ' button not found'); button.click(); return true; })()`,
     ])
 }
 


### PR DESCRIPTION
## Summary
- validate every retained cockpit SessionCommand shape in the web command client
- extend the broker/web smoke to queue Status, Pause, and Continue controls
- extend the real-TUI smoke to assert accepted status_request and rejected idle pause_current_turn outcomes

## Validation
- confirm: pnpm lint:dry-run
- pnpm --filter @code-everywhere/web test -- cockpitCommands.test.ts
- pnpm smoke:cockpit:web
- pnpm smoke:cockpit:real-tui
- pnpm validate && pnpm smoke:cockpit:web && pnpm smoke:cockpit:real-tui
- (../code/code-rs) cargo test -p code-tui remote_inbox --features test-helpers