### PR TITLE
Cover real TUI continue rejection

### DIFF
--- a/scripts/smoke-cockpit-real-tui-live-loop.mjs
+++ b/scripts/smoke-cockpit-real-tui-live-loop.mjs
@@ -70,6 +70,17 @@ const run = async () => {
             state: "rejected",
             detail: "no active turn is running",
         })
+        await clickFirstCommandButton(uiBrowser, session, "Continue")
+        const continueOutcome = await waitForCommandOutcome(brokerUrl, "continue_autonomously")
+        assertEqual(continueOutcome.status, "rejected", "idle continue command outcome")
+        assertEqual(continueOutcome.reason, "no prior session history to continue", "idle continue rejection reason")
+        assertEqual(continueOutcome.sessionId, tuiSession.sessionId, "idle continue command session")
+        assertEqual(continueOutcome.sessionEpoch, tuiSession.sessionEpoch, "idle continue command epoch")
+        await waitForCommandHistoryEntry(uiBrowser, session, {
+            label: "Continue Autonomously",
+            state: "rejected",
+            detail: "no prior session history to continue",
+        })
 
         await stopProcess(broker)
         broker = null


### PR DESCRIPTION
## Summary
- extend the real-TUI smoke to click Continue in a fresh TUI session
- assert the real TUI rejects continue_autonomously with no prior session history
- verify the rejected Continue Autonomously outcome is visible in cockpit command history

## Validation
- pnpm smoke:cockpit:real-tui
- confirm: pnpm lint:dry-run && pnpm validate && pnpm smoke:cockpit:web && pnpm smoke:cockpit:real-tui