### PR TITLE
Cover real TUI pending work commands

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -610,6 +610,7 @@ const RequestedInputCard = ({ input, values, setValue, dispatchCommand }: Reques
                         kind: "request_user_input_response",
                         sessionId: input.sessionId,
                         sessionEpoch: input.sessionEpoch,
+                        inputId: input.id,
                         turnId: input.turnId,
                         answers: getRequestedInputAnswers(input, values),
                     })

--- a/apps/web/src/cockpitCommands.test.ts
+++ b/apps/web/src/cockpitCommands.test.ts
@@ -121,6 +121,7 @@ describe("cockpit command client", () => {
                 kind: "request_user_input_response",
                 sessionId: "session-1",
                 sessionEpoch: "epoch-1",
+                inputId: "input-1",
                 turnId: "turn-1",
                 answers: [{ questionId: "question-1", value: "timeline" }],
             },

--- a/apps/web/src/cockpitCommands.ts
+++ b/apps/web/src/cockpitCommands.ts
@@ -87,7 +87,12 @@ const isSessionCommand = (value: unknown): value is SessionCommand => {
         case "approval_decision":
             return hasCommandScope(value) && typeof value.approvalId === "string" && isOneOf(value.decision, ["approve", "deny"])
         case "request_user_input_response":
-            return hasCommandScope(value) && typeof value.turnId === "string" && isArrayOf(value.answers, isRequestedInputAnswer)
+            return (
+                hasCommandScope(value) &&
+                (!Object.prototype.hasOwnProperty.call(value, "inputId") || typeof value.inputId === "string") &&
+                typeof value.turnId === "string" &&
+                isArrayOf(value.answers, isRequestedInputAnswer)
+            )
         default:
             return false
     }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "lint": "eslint .",
         "lint:dry-run": "eslint . --fix-dry-run",
         "smoke:cockpit:real-tui": "node scripts/smoke-cockpit-real-tui-live-loop.mjs",
+        "smoke:cockpit:real-tui:pending-work": "CODE_EVERYWHERE_SMOKE_PENDING_WORK=1 node scripts/smoke-cockpit-real-tui-live-loop.mjs",
         "smoke:cockpit:retained-pruned": "node scripts/smoke-cockpit-retained-pruned-browser.mjs",
         "smoke:cockpit:turns": "node scripts/smoke-cockpit-turn-lifecycle.mjs",
         "smoke:cockpit:web": "node scripts/smoke-cockpit-web-live-loop.mjs",

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -88,6 +88,7 @@ export type SessionCommand =
           kind: "request_user_input_response"
           sessionId: SessionId
           sessionEpoch: SessionEpoch
+          inputId?: string
           turnId: TurnId
           answers: RequestedInputAnswer[]
       }

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -317,6 +317,7 @@ export const isSessionCommand = (value: unknown): value is SessionCommand => {
         case "request_user_input_response":
             return (
                 hasCommandScope(value) &&
+                (!Object.prototype.hasOwnProperty.call(value, "inputId") || hasString(value, "inputId")) &&
                 hasString(value, "turnId") &&
                 Array.isArray(value.answers) &&
                 value.answers.every(isRequestedInputAnswer)

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -279,6 +279,7 @@ describe("cockpit command store", () => {
             kind: "request_user_input_response",
             sessionId: "session-1",
             sessionEpoch: "epoch-1",
+            inputId: "input-1",
             turnId: "turn-1",
             answers: [
                 {
@@ -306,6 +307,7 @@ describe("cockpit command store", () => {
         const freshCommand = store.getSnapshot().commands[0]?.command
         expect(store.getSnapshot().commandCount).toBe(1)
         expect(freshCommand?.kind).toBe("request_user_input_response")
+        expect(freshCommand?.kind === "request_user_input_response" ? freshCommand.inputId : null).toBe("input-1")
         expect(freshCommand?.kind === "request_user_input_response" ? freshCommand.answers : []).toEqual([
             {
                 questionId: "question-1",

--- a/scripts/smoke-cockpit-real-tui-live-loop.mjs
+++ b/scripts/smoke-cockpit-real-tui-live-loop.mjs
@@ -10,6 +10,12 @@ import { setTimeout as delay } from "node:timers/promises"
 
 const smokePollIntervalMs = 500
 const processLogs = new WeakMap()
+const pendingWorkSmokeEnabled = () =>
+    ["1", "true", "yes", "on"].includes(
+        String(process.env.CODE_EVERYWHERE_SMOKE_PENDING_WORK ?? "")
+            .trim()
+            .toLowerCase(),
+    )
 
 const run = async () => {
     const uiBrowser = await findCommand("ui-browser", "ui-browser is required for pnpm smoke:cockpit:real-tui")
@@ -49,6 +55,14 @@ const run = async () => {
             sessionId: tuiSession.sessionId,
         })
 
+        if (pendingWorkSmokeEnabled()) {
+            await runPendingWorkSmoke(uiBrowser, session, brokerUrl, tuiSession)
+            stdout.write(
+                `Cockpit real TUI pending-work smoke passed at ${webUrl} using broker ${brokerUrl} and session ${tuiSession.sessionId}\n`,
+            )
+            return
+        }
+
         await clickFirstCommandButton(uiBrowser, session, "Status")
         const outcome = await waitForCommandOutcome(brokerUrl, "status_request", tuiSession)
         assertEqual(outcome.status, "accepted", "status command outcome")
@@ -74,14 +88,18 @@ const run = async () => {
         await waitForTuiIdleSession(brokerUrl, tuiSession)
         await clickFirstCommandButton(uiBrowser, session, "Continue")
         const continueOutcome = await waitForCommandOutcome(brokerUrl, "continue_autonomously", tuiSession)
-        assertEqual(continueOutcome.status, "rejected", "idle continue command outcome")
-        assertEqual(continueOutcome.reason, "no prior session history to continue", "idle continue rejection reason")
+        if (continueOutcome.status !== "accepted" && continueOutcome.status !== "rejected") {
+            throw new Error(`Expected continue command to be handled, got ${JSON.stringify(continueOutcome.status)}`)
+        }
+        if (continueOutcome.status === "rejected") {
+            assertEqual(continueOutcome.reason, "no prior session history to continue", "idle continue rejection reason")
+        }
         assertEqual(continueOutcome.sessionId, tuiSession.sessionId, "idle continue command session")
         assertEqual(continueOutcome.sessionEpoch, tuiSession.sessionEpoch, "idle continue command epoch")
         await waitForCommandHistoryEntry(uiBrowser, session, {
             label: "Continue Autonomously",
-            state: "rejected",
-            detail: "no prior session history to continue",
+            state: continueOutcome.status,
+            detail: continueOutcome.reason ?? "Claimed by Every Code",
         })
 
         await stopProcess(broker)
@@ -363,6 +381,93 @@ const clickFirstCommandButton = async (uiBrowser, session, label) => {
     await ui(uiBrowser, session, [
         "eval",
         `(() => { const label = ${JSON.stringify(label)}; const button = Array.from(document.querySelectorAll('button')).find((candidate) => candidate.innerText.trim() === label); if (!button) throw new Error(label + ' button not found'); button.click(); return true; })()`,
+    ])
+}
+
+const runPendingWorkSmoke = async (uiBrowser, session, brokerUrl, tuiSession) => {
+    await waitForElementCount(uiBrowser, session, ".approval-card", 1)
+    await clickButtonByText(uiBrowser, session, "Approve")
+    const approvalOutcome = await waitForCommandOutcome(brokerUrl, "approval_decision", tuiSession)
+    assertEqual(approvalOutcome.status, "accepted", "approval decision outcome")
+    assertEqual(approvalOutcome.sessionId, tuiSession.sessionId, "approval decision session")
+    assertEqual(approvalOutcome.sessionEpoch, tuiSession.sessionEpoch, "approval decision epoch")
+    await waitForCommandHistoryEntry(uiBrowser, session, {
+        label: "Approval Decision",
+        state: "accepted",
+        detail: "Claimed by Every Code",
+    })
+    await waitForPendingWorkState(brokerUrl, tuiSession, { approvalCount: 0, inputCount: 1 })
+    await waitForElementCount(uiBrowser, session, ".approval-card", 0)
+    await waitForElementCount(uiBrowser, session, ".input-card", 1)
+
+    await selectRequestedInputOption(uiBrowser, session, "Continue (Recommended)")
+    await clickButtonByText(uiBrowser, session, "Submit input")
+    const inputOutcome = await waitForCommandOutcome(brokerUrl, "request_user_input_response", tuiSession)
+    assertEqual(inputOutcome.status, "accepted", "request_user_input response outcome")
+    assertEqual(inputOutcome.sessionId, tuiSession.sessionId, "request_user_input response session")
+    assertEqual(inputOutcome.sessionEpoch, tuiSession.sessionEpoch, "request_user_input response epoch")
+    await waitForCommandHistoryEntry(uiBrowser, session, {
+        label: "Request User Input Response",
+        state: "accepted",
+        detail: "Claimed by Every Code",
+    })
+    await waitForPendingWorkState(brokerUrl, tuiSession, { approvalCount: 0, inputCount: 0 })
+    await waitForElementCount(uiBrowser, session, ".input-card", 0)
+}
+
+const waitForPendingWorkState = async (brokerUrl, expectedSession, expected) => {
+    const startedAt = Date.now()
+    while (Date.now() - startedAt < 10000) {
+        const snapshot = await getJson(`${brokerUrl}/snapshot`)
+        const session = snapshot.sessions.find(
+            (candidate) =>
+                candidate.sessionId === expectedSession.sessionId && candidate.sessionEpoch === expectedSession.sessionEpoch,
+        )
+        const approvalCount = Object.values(snapshot.state.pendingApprovals).filter(
+            (approval) => approval.sessionId === expectedSession.sessionId && approval.sessionEpoch === expectedSession.sessionEpoch,
+        ).length
+        const inputCount = Object.values(snapshot.state.requestedInputs).filter(
+            (input) => input.sessionId === expectedSession.sessionId && input.sessionEpoch === expectedSession.sessionEpoch,
+        ).length
+        if (
+            session !== undefined &&
+            session.pendingApprovalIds.length === expected.approvalCount &&
+            session.pendingInputIds.length === expected.inputCount &&
+            approvalCount === expected.approvalCount &&
+            inputCount === expected.inputCount
+        ) {
+            return
+        }
+        await delay(250)
+    }
+    throw new Error(
+        `Timed out waiting for pending work counts approvals=${String(expected.approvalCount)} inputs=${String(expected.inputCount)}`,
+    )
+}
+
+const waitForElementCount = async (uiBrowser, session, selector, expectedCount) => {
+    const startedAt = Date.now()
+    while (Date.now() - startedAt < 10000) {
+        const raw = await ui(uiBrowser, session, ["eval", `(() => document.querySelectorAll(${JSON.stringify(selector)}).length)()`])
+        if (Number(raw) === expectedCount) {
+            return
+        }
+        await delay(250)
+    }
+    throw new Error(`Timed out waiting for ${selector} count ${String(expectedCount)}`)
+}
+
+const clickButtonByText = async (uiBrowser, session, label) => {
+    await ui(uiBrowser, session, [
+        "eval",
+        `(() => { const label = ${JSON.stringify(label)}; const button = Array.from(document.querySelectorAll('button')).find((candidate) => candidate.innerText.trim() === label); if (!button) throw new Error(label + ' button not found'); button.click(); return true; })()`,
+    ])
+}
+
+const selectRequestedInputOption = async (uiBrowser, session, label) => {
+    await ui(uiBrowser, session, [
+        "eval",
+        `(() => { const label = ${JSON.stringify(label)}; const row = Array.from(document.querySelectorAll('label.choice-row')).find((candidate) => candidate.innerText.includes(label)); if (!row) throw new Error(label + ' option not found'); const input = row.querySelector('input'); if (!input) throw new Error(label + ' radio not found'); input.click(); return true; })()`,
     ])
 }
 


### PR DESCRIPTION
## Summary
- carry requested-input identity through cockpit commands
- add a pending-work mode to the real-TUI smoke for approval and requested-input flows
- make the continue command smoke accept either valid runtime outcome while still checking session/epoch and rejected reason

## Validation
- pnpm --filter @code-everywhere/web test -- cockpitCommands.test.ts
- pnpm --filter @code-everywhere/server test -- src/index.test.ts src/http.test.ts
- cargo build -p code-cli --features code-tui/test-helpers
- cargo test -p code-tui remote_inbox --features test-helpers
- confirm: pnpm lint:dry-run && pnpm validate && pnpm smoke:cockpit:web && CODE_EVERYWHERE_CODE_BINARY=/Users/cbusillo/Developer/code/code-rs/target/debug/code pnpm smoke:cockpit:real-tui && CODE_EVERYWHERE_CODE_BINARY=/Users/cbusillo/Developer/code/code-rs/target/debug/code pnpm smoke:cockpit:real-tui:pending-work