### PR TITLE
Submit requested input freeform notes

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -41,8 +41,10 @@ import {
     getDraftValue,
     getRequestedInputAnswers,
     getRequestedInputAnswerValues,
+    getRequestedInputNoteValue,
     setDraftValue,
     setRequestedInputAnswerValue,
+    setRequestedInputNoteValue,
     type DraftMap,
 } from "./cockpitDrafts"
 import { describeTransportStatus, useCockpitView, type CockpitTransportStatus } from "./cockpitTransport"
@@ -132,6 +134,7 @@ export const App = () => {
     const activeCommandHistory = getCommandHistoryEntries(cockpit.commands, cockpit.commandOutcomes, activeSession)
     const reply = getDraftValue(replyDrafts, activeSession?.sessionId)
     const inputAnswerValues = getRequestedInputAnswerValues(inputAnswerDrafts, activeInput)
+    const inputNote = getRequestedInputNoteValue(inputAnswerDrafts, activeInput)
 
     const setReply = (value: string) => {
         if (activeSession === undefined) {
@@ -147,6 +150,14 @@ export const App = () => {
         }
 
         setInputAnswerDrafts((drafts) => setRequestedInputAnswerValue(drafts, activeInput.id, questionId, value))
+    }
+
+    const setInputNote = (value: string) => {
+        if (activeInput === undefined) {
+            return
+        }
+
+        setInputAnswerDrafts((drafts) => setRequestedInputNoteValue(drafts, activeInput.id, value))
     }
 
     const dispatchCommand = (label: string, command: SessionCommand) => {
@@ -213,7 +224,9 @@ export const App = () => {
                                 approval={activeApproval}
                                 requestedInput={activeInput}
                                 inputAnswerValues={inputAnswerValues}
+                                inputNote={inputNote}
                                 setInputAnswer={setInputAnswer}
+                                setInputNote={setInputNote}
                                 commandLog={commandLog}
                                 commandHistory={activeCommandHistory}
                                 dispatchCommand={dispatchCommand}
@@ -419,7 +432,9 @@ type ActionRailProps = {
     approval: PendingApproval | undefined
     requestedInput: RequestedInput | undefined
     inputAnswerValues: Record<string, string>
+    inputNote: string
     setInputAnswer: (questionId: string, value: string) => void
+    setInputNote: (value: string) => void
     commandLog: string
     commandHistory: CommandHistoryEntry[]
     dispatchCommand: (label: string, command: SessionCommand) => void
@@ -430,7 +445,9 @@ const ActionRail = ({
     approval,
     requestedInput,
     inputAnswerValues,
+    inputNote,
     setInputAnswer,
+    setInputNote,
     commandLog,
     commandHistory,
     dispatchCommand,
@@ -457,7 +474,9 @@ const ActionRail = ({
                 <RequestedInputCard
                     input={requestedInput}
                     values={inputAnswerValues}
+                    note={inputNote}
                     setValue={setInputAnswer}
+                    setNote={setInputNote}
                     dispatchCommand={dispatchCommand}
                 />
             )}
@@ -560,11 +579,13 @@ const ApprovalCard = ({
 type RequestedInputCardProps = {
     input: RequestedInput
     values: Record<string, string>
+    note: string
     setValue: (questionId: string, value: string) => void
+    setNote: (value: string) => void
     dispatchCommand: (label: string, command: SessionCommand) => void
 }
 
-const RequestedInputCard = ({ input, values, setValue, dispatchCommand }: RequestedInputCardProps) => {
+const RequestedInputCard = ({ input, values, note, setValue, setNote, dispatchCommand }: RequestedInputCardProps) => {
     if (input.questions.length === 0) {
         return null
     }
@@ -601,7 +622,12 @@ const RequestedInputCard = ({ input, values, setValue, dispatchCommand }: Reques
             <label className="freeform-label" htmlFor="input-freeform">
                 Optional note
             </label>
-            <textarea id="input-freeform" placeholder="Add context for the session..." />
+            <textarea
+                id="input-freeform"
+                placeholder="Add context for the session..."
+                value={note}
+                onChange={(event) => setNote(event.currentTarget.value)}
+            />
             <button
                 className="primary-button full-width"
                 type="button"
@@ -612,7 +638,7 @@ const RequestedInputCard = ({ input, values, setValue, dispatchCommand }: Reques
                         sessionEpoch: input.sessionEpoch,
                         inputId: input.id,
                         turnId: input.turnId,
-                        answers: getRequestedInputAnswers(input, values),
+                        answers: getRequestedInputAnswers(input, values, note),
                     })
                 }
             >

--- a/apps/web/src/cockpitDrafts.test.ts
+++ b/apps/web/src/cockpitDrafts.test.ts
@@ -7,8 +7,11 @@ import {
     getRequestedInputAnswers,
     getRequestedInputAnswerValues,
     getRequestedInputDefault,
+    getRequestedInputNoteValue,
+    requestedInputNoteQuestionId,
     setDraftValue,
     setRequestedInputAnswerValue,
+    setRequestedInputNoteValue,
 } from "./cockpitDrafts"
 
 describe("cockpit draft state", () => {
@@ -64,5 +67,12 @@ describe("cockpit draft state", () => {
             { questionId: "question-1", value: "recommended" },
             { questionId: "question-2", value: "project" },
         ])
+        expect(getRequestedInputAnswers(input, values, "  Add CI evidence.  ")).toEqual([
+            { questionId: "question-1", value: "recommended" },
+            { questionId: "question-2", value: "project" },
+            { questionId: requestedInputNoteQuestionId, value: "Add CI evidence." },
+        ])
+        expect(getRequestedInputNoteValue(setRequestedInputNoteValue({}, "input-1", "note text"), input)).toBe("note text")
+        expect(getRequestedInputNoteValue({}, undefined)).toBe("")
     })
 })

--- a/apps/web/src/cockpitDrafts.ts
+++ b/apps/web/src/cockpitDrafts.ts
@@ -19,6 +19,10 @@ export const getRequestedInputDefault = (question: RequestedInputQuestion | unde
 
 export const getRequestedInputDraftKey = (inputId: string, questionId: string): string => `${inputId}:${questionId}`
 
+export const requestedInputNoteQuestionId = "__note"
+
+export const getRequestedInputNoteDraftKey = (inputId: string): string => `${inputId}:note`
+
 export const getRequestedInputAnswerValues = (drafts: DraftMap, input: RequestedInput | undefined): Record<string, string> =>
     Object.fromEntries(
         input?.questions.map((question) => [
@@ -30,8 +34,24 @@ export const getRequestedInputAnswerValues = (drafts: DraftMap, input: Requested
 export const setRequestedInputAnswerValue = (drafts: DraftMap, inputId: string, questionId: string, value: string): DraftMap =>
     setDraftValue(drafts, getRequestedInputDraftKey(inputId, questionId), value)
 
-export const getRequestedInputAnswers = (input: RequestedInput, values: Record<string, string>): RequestedInputAnswer[] =>
-    input.questions.map((question) => ({
+export const getRequestedInputNoteValue = (drafts: DraftMap, input: RequestedInput | undefined): string =>
+    getDraftValue(drafts, input === undefined ? undefined : getRequestedInputNoteDraftKey(input.id))
+
+export const setRequestedInputNoteValue = (drafts: DraftMap, inputId: string, value: string): DraftMap =>
+    setDraftValue(drafts, getRequestedInputNoteDraftKey(inputId), value)
+
+export const getRequestedInputAnswers = (
+    input: RequestedInput,
+    values: Record<string, string>,
+    note = "",
+): RequestedInputAnswer[] => {
+    const answers = input.questions.map((question) => ({
         questionId: question.id,
         value: values[question.id] ?? getRequestedInputDefault(question),
     }))
+    const trimmedNote = note.trim()
+    if (trimmedNote !== "") {
+        answers.push({ questionId: requestedInputNoteQuestionId, value: trimmedNote })
+    }
+    return answers
+}

--- a/scripts/smoke-cockpit-real-tui-live-loop.mjs
+++ b/scripts/smoke-cockpit-real-tui-live-loop.mjs
@@ -10,6 +10,7 @@ import { setTimeout as delay } from "node:timers/promises"
 
 const smokePollIntervalMs = 500
 const processLogs = new WeakMap()
+const requestedInputSmokeNote = "Freeform note from the real TUI smoke."
 const pendingWorkSmokeEnabled = () =>
     ["1", "true", "yes", "on"].includes(
         String(process.env.CODE_EVERYWHERE_SMOKE_PENDING_WORK ?? "")
@@ -418,7 +419,9 @@ const runPendingWorkSmoke = async (uiBrowser, session, brokerUrl, tuiSession) =>
     await waitForElementCount(uiBrowser, session, ".input-card", 1)
 
     await selectRequestedInputOption(uiBrowser, session, "Continue (Recommended)")
+    await fillRequestedInputNote(uiBrowser, session, requestedInputSmokeNote)
     await clickButtonByText(uiBrowser, session, "Submit input")
+    await waitForSubmittedInputAnswer(brokerUrl, tuiSession, "__note", requestedInputSmokeNote)
     const inputOutcome = await waitForCommandOutcome(brokerUrl, "request_user_input_response", tuiSession)
     assertEqual(inputOutcome.status, "accepted", "request_user_input response outcome")
     assertEqual(inputOutcome.sessionId, tuiSession.sessionId, "request_user_input response session")
@@ -486,6 +489,32 @@ const selectRequestedInputOption = async (uiBrowser, session, label) => {
         "eval",
         `(() => { const label = ${JSON.stringify(label)}; const row = Array.from(document.querySelectorAll('label.choice-row')).find((candidate) => candidate.innerText.includes(label)); if (!row) throw new Error(label + ' option not found'); const input = row.querySelector('input'); if (!input) throw new Error(label + ' radio not found'); input.click(); return true; })()`,
     ])
+}
+
+const fillRequestedInputNote = async (uiBrowser, session, note) => {
+    await ui(uiBrowser, session, [
+        "eval",
+        `(() => { const textarea = document.querySelector('#input-freeform'); if (!textarea) throw new Error('Input note textarea not found'); const value = ${JSON.stringify(note)}; const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set; setter.call(textarea, value); textarea.dispatchEvent(new Event('input', { bubbles: true })); return true; })()`,
+    ])
+}
+
+const waitForSubmittedInputAnswer = async (brokerUrl, expectedSession, questionId, value) => {
+    const startedAt = Date.now()
+    while (Date.now() - startedAt < 10000) {
+        const snapshot = await getJson(`${brokerUrl}/commands`)
+        const command = snapshot.commands.find(
+            (record) =>
+                record.command.kind === "request_user_input_response" &&
+                record.command.sessionId === expectedSession.sessionId &&
+                record.command.sessionEpoch === expectedSession.sessionEpoch,
+        )?.command
+        const answer = command?.answers?.find((candidate) => candidate.questionId === questionId)
+        if (answer?.value === value) {
+            return
+        }
+        await delay(250)
+    }
+    throw new Error(`Timed out waiting for submitted requested-input answer ${questionId}`)
 }
 
 const sendReply = async (uiBrowser, session, message) => {


### PR DESCRIPTION
## Summary
- make the requested-input optional note a controlled draft field
- submit non-empty notes as a stable __note requested-input answer
- extend the real-TUI pending-work smoke to verify the note is retained in the submitted command payload

## Validation
- confirm: pnpm lint:dry-run && pnpm --filter @code-everywhere/web test -- cockpitDrafts.test.ts cockpitCommands.test.ts
- CODE_EVERYWHERE_CODE_BINARY=/Users/cbusillo/Developer/code/code-rs/target/debug/code pnpm smoke:cockpit:real-tui:pending-work
- confirm: pnpm lint:dry-run && pnpm validate && CODE_EVERYWHERE_CODE_BINARY=/Users/cbusillo/Developer/code/code-rs/target/debug/code pnpm smoke:cockpit:real-tui && CODE_EVERYWHERE_CODE_BINARY=/Users/cbusillo/Developer/code/code-rs/target/debug/code pnpm smoke:cockpit:real-tui:pending-work && CODE_EVERYWHERE_CODE_BINARY=/Users/cbusillo/Developer/code/code-rs/target/debug/code pnpm smoke:cockpit:real-tui:approval-deny