### PR TITLE
Add current turn detail summary

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -39,12 +39,15 @@ import { canPostCockpitCommand, postCockpitCommand } from "./cockpitCommands"
 import {
     getAttentionSessions,
     getOperatorAttentionSummary,
+    getSessionDetailSummary,
     hasActionableRequestedInput,
     statusLabels,
     type CockpitSession,
     type OperatorAttentionItem,
     type OperatorAttentionKind,
     type OperatorAttentionSummary,
+    type SessionDetailSummary,
+    type TurnStepSummary,
 } from "./cockpitData"
 import {
     getDraftValue,
@@ -121,6 +124,8 @@ const stepKindLabel: Record<TurnStep["kind"], string> = {
     artifact: "Artifact",
     error: "Error",
 }
+
+const stepKindOrder: TurnStep["kind"][] = ["message", "tool", "diff", "artifact", "status", "error"]
 
 const turnRailTone: Record<TurnStatus, string> = {
     running: "is-running",
@@ -476,6 +481,8 @@ type SessionDetailProps = {
 
 const SessionDetail = ({ session, reply, setReply, dispatchCommand }: SessionDetailProps) => (
     <section className="panel detail-panel" aria-label="Active session detail">
+        <CurrentTurnSummary summary={getSessionDetailSummary(session)} />
+
         <div className="detail-header">
             <div className="detail-title-block">
                 <div className="detail-status-row">
@@ -553,6 +560,48 @@ const SessionDetail = ({ session, reply, setReply, dispatchCommand }: SessionDet
             ))}
         </section>
     </section>
+)
+
+const CurrentTurnSummary = ({ summary }: { summary: SessionDetailSummary }) => {
+    const turn = summary.currentTurn ?? summary.latestTurn
+
+    return (
+        <section className="current-turn-summary" aria-label="Current turn summary">
+            <div>
+                <p className="eyebrow">Current turn</p>
+                <h3>{turn?.title ?? "No turns yet"}</h3>
+                <p>{turn?.summary ?? "This session has not published turn detail yet."}</p>
+            </div>
+            <div className="turn-summary-metrics" aria-label="Turn detail counts">
+                <MetricPill label="Steps" value={summary.totalSteps} />
+                <MetricPill label="Blocked" value={summary.blockedCount} tone={summary.blockedCount > 0 ? "warning" : undefined} />
+                <MetricPill label="Errors" value={summary.errorCount} tone={summary.errorCount > 0 ? "danger" : undefined} />
+            </div>
+            <StepKindSummary counts={summary.stepCounts} />
+        </section>
+    )
+}
+
+const MetricPill = ({ label, value, tone }: { label: string; value: number; tone?: "danger" | "warning" | undefined }) => (
+    <span className={`detail-metric ${tone === undefined ? "" : `is-${tone}`}`}>
+        <strong>{value}</strong>
+        {label}
+    </span>
+)
+
+const StepKindSummary = ({ counts }: { counts: TurnStepSummary }) => (
+    <div className="step-kind-summary" aria-label="Step categories">
+        {stepKindOrder.map((kind) => {
+            const Icon = stepKindIcon[kind]
+            return (
+                <span key={kind}>
+                    <Icon size={13} aria-hidden="true" />
+                    <strong>{counts[kind]}</strong>
+                    {stepKindLabel[kind]}
+                </span>
+            )
+        })}
+    </div>
 )
 
 type ActionRailProps = {

--- a/apps/web/src/cockpitData.test.ts
+++ b/apps/web/src/cockpitData.test.ts
@@ -7,6 +7,7 @@ import {
     createCockpitFixtureFromSnapshot,
     getAttentionSessions,
     getOperatorAttentionSummary,
+    getSessionDetailSummary,
     statusLabels,
 } from "./cockpitData"
 
@@ -141,5 +142,28 @@ describe("cockpit fake data", () => {
 
         expect(summary.counts.input).toBe(1)
         expect(summary.items.some((item) => item.id === "input:input-empty")).toBe(false)
+    })
+
+    it("summarizes current turn detail and step categories", () => {
+        const session = cockpitFixture.sessions.find((candidate) => candidate.sessionId === "ce-alpha")
+        expect(session).toBeDefined()
+        if (session === undefined) {
+            throw new Error("Expected ce-alpha fixture session")
+        }
+
+        const summary = getSessionDetailSummary(session)
+
+        expect(summary.currentTurn?.id).toBe("turn-alpha-3")
+        expect(summary.latestTurn?.id).toBe("turn-alpha-3")
+        expect(summary.totalSteps).toBe(2)
+        expect(summary.stepCounts).toMatchObject({
+            artifact: 0,
+            diff: 0,
+            message: 0,
+            tool: 1,
+            status: 1,
+        })
+        expect(summary.blockedCount).toBe(3)
+        expect(summary.errorCount).toBe(0)
     })
 })

--- a/apps/web/src/cockpitData.ts
+++ b/apps/web/src/cockpitData.ts
@@ -44,6 +44,17 @@ export type CockpitFixture = {
     staleEvents: StaleCockpitEvent[]
 }
 
+export type TurnStepSummary = Record<SessionTurn["steps"][number]["kind"], number>
+
+export type SessionDetailSummary = {
+    currentTurn: SessionTurn | undefined
+    latestTurn: SessionTurn | undefined
+    stepCounts: TurnStepSummary
+    totalSteps: number
+    errorCount: number
+    blockedCount: number
+}
+
 export type OperatorAttentionKind = "approval" | "input" | "error" | "blocked" | "stale-command" | "rejected-command"
 
 export type OperatorAttentionItem = {
@@ -552,6 +563,55 @@ export const getSessionById = (sessionId: SessionId): CockpitSession => {
 
 export const getAttentionSessions = (sessions: CockpitSession[]): CockpitSession[] =>
     sessions.filter((session) => session.attention !== "none")
+
+export const getSessionDetailSummary = (session: CockpitSession): SessionDetailSummary => {
+    const currentTurn = session.currentTurnId === null ? undefined : session.turns.find((turn) => turn.id === session.currentTurnId)
+    const latestTurn = currentTurn ?? session.turns.at(-1)
+    const detailTurn = currentTurn ?? latestTurn
+    const stepCounts = emptyTurnStepSummary()
+    let errorCount = 0
+    let blockedCount = 0
+
+    if (detailTurn !== undefined) {
+        if (detailTurn.status === "error") {
+            errorCount += 1
+        }
+        if (
+            detailTurn.status === "blocked" ||
+            detailTurn.status === "waiting-for-approval" ||
+            detailTurn.status === "waiting-for-input"
+        ) {
+            blockedCount += 1
+        }
+        for (const step of detailTurn.steps) {
+            stepCounts[step.kind] += 1
+            if (step.state === "error") {
+                errorCount += 1
+            }
+            if (step.state === "blocked") {
+                blockedCount += 1
+            }
+        }
+    }
+
+    return {
+        currentTurn,
+        latestTurn,
+        stepCounts,
+        totalSteps: Object.values(stepCounts).reduce((total, count) => total + count, 0),
+        errorCount,
+        blockedCount,
+    }
+}
+
+const emptyTurnStepSummary = (): TurnStepSummary => ({
+    message: 0,
+    tool: 0,
+    status: 0,
+    diff: 0,
+    artifact: 0,
+    error: 0,
+})
 
 export const getOperatorAttentionSummary = (
     fixture: Pick<CockpitFixture, "approvals" | "commandOutcomes" | "requestedInputs" | "sessions">,

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -457,6 +457,87 @@ code {
     background: var(--bg-base);
 }
 
+.current-turn-summary {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 10px 14px;
+    border-bottom: 1px solid var(--border-default);
+    background: var(--bg-elevated);
+    padding: 12px 20px;
+}
+
+.current-turn-summary h3,
+.current-turn-summary p {
+    margin: 0;
+}
+
+.current-turn-summary h3 {
+    margin-top: 3px;
+    font-size: 15px;
+    font-weight: 700;
+    letter-spacing: 0;
+}
+
+.current-turn-summary p:not(.eyebrow) {
+    margin-top: 4px;
+    color: var(--fg-2);
+    font-size: 12.5px;
+    line-height: 1.45;
+}
+
+.turn-summary-metrics,
+.step-kind-summary {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.turn-summary-metrics {
+    justify-content: flex-end;
+}
+
+.detail-metric,
+.step-kind-summary span {
+    display: inline-flex;
+    min-height: 26px;
+    align-items: center;
+    gap: 5px;
+    border: 1px solid var(--border-default);
+    border-radius: 999px;
+    background: var(--bg-sunken);
+    color: var(--fg-2);
+    padding: 3px 8px;
+    font-size: 11px;
+    white-space: nowrap;
+}
+
+.detail-metric strong,
+.step-kind-summary strong {
+    color: var(--fg-1);
+    font-family: var(--font-mono);
+    font-size: 12px;
+}
+
+.detail-metric.is-warning {
+    border-color: var(--warning-border);
+    background: var(--warning-bg-soft);
+    color: var(--warning-text);
+}
+
+.detail-metric.is-danger {
+    border-color: var(--danger-border);
+    background: var(--danger-bg-soft);
+    color: var(--danger-text);
+}
+
+.step-kind-summary {
+    grid-column: 1 / -1;
+}
+
+.step-kind-summary svg {
+    color: var(--fg-3);
+}
+
 .empty-cockpit-panel {
     justify-content: center;
     padding: 20px;
@@ -1434,6 +1515,15 @@ legend {
         padding: 10px 16px;
     }
 
+    .current-turn-summary {
+        grid-template-columns: 1fr;
+        padding: 10px 16px;
+    }
+
+    .turn-summary-metrics {
+        justify-content: flex-start;
+    }
+
     .detail-title-block h2 {
         margin-top: 7px;
         font-size: 19px;
@@ -1722,6 +1812,12 @@ legend {
 
     .metadata-strip {
         grid-template-columns: 1fr;
+    }
+
+    .detail-metric,
+    .step-kind-summary span {
+        flex: 1 1 92px;
+        justify-content: center;
     }
 
     .attention-overview {

--- a/docs/every-code-integration.md
+++ b/docs/every-code-integration.md
@@ -94,6 +94,9 @@ It should keep the next action visible and make transport health explicit:
   more than one pending item.
 - Requested-input records without questions are not actionable and are excluded
   from the attention queue and active pending-work card.
+- Session detail starts with a current-turn summary that shows the active or
+  latest turn title, summary, total projected steps, blocked/error signals, and
+  step-kind counts before lower-priority metadata and history.
 - A compact state banner explains fixture mode, first live connection, broker
   fallback/reconnect, healthy-but-empty live broker snapshots, and retained
   stale-event evidence.


### PR DESCRIPTION
## Summary
- add a current-turn summary card above session metadata
- derive current/latest turn step counts, blocked signals, and error signals for the web cockpit
- document the current-turn detail surface

## Validation
- pnpm lint:dry-run
- pnpm validate
- pnpm smoke:cockpit:web
- pnpm smoke:cockpit:retained-pruned
- pnpm smoke:cockpit:turns
- browser UI review at 1024x768 and 390x844