### PR TITLE
Surface command outcome history

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,5 @@
 import * as Dialog from "@radix-ui/react-dialog"
 import type {
-    CommandOutcome,
     PendingApproval,
     RequestedInput,
     SessionCommand,
@@ -9,7 +8,6 @@ import type {
     TurnStatus,
     TurnStep,
 } from "@code-everywhere/contracts"
-import type { CockpitCommandRecord } from "@code-everywhere/server"
 import {
     AlertCircle,
     Bell,
@@ -38,11 +36,15 @@ import { useMemo, useState } from "react"
 import { canPostCockpitCommand, postCockpitCommand } from "./cockpitCommands"
 import {
     getAttentionSessions,
+    getCommandHistoryEntries,
+    getCommandOutcomeSummary,
     getOperatorAttentionSummary,
     getSessionDetailSummary,
     hasActionableRequestedInput,
     statusLabels,
     type CockpitSession,
+    type CommandHistoryEntry,
+    type CommandOutcomeSummary,
     type OperatorAttentionItem,
     type OperatorAttentionKind,
     type OperatorAttentionSummary,
@@ -64,14 +66,6 @@ import { describeTransportStatus, useCockpitView, type CockpitTransportStatus } 
 const selectedSessionId = "ce-alpha"
 
 type IconComponent = typeof CirclePlay
-
-type CommandHistoryEntry = {
-    id: string
-    label: string
-    state: "queued" | "delivered" | "accepted" | "rejected"
-    timestamp: string
-    detail: string
-}
 
 type CockpitStateSurface = {
     tone: "info" | "warning" | "success"
@@ -687,6 +681,7 @@ const ActionRail = ({
             <div className="mock-log" aria-live="polite">
                 <span>Command status</span>
                 <p>{commandLog}</p>
+                <CommandOutcomeOverview summary={getCommandOutcomeSummary(commandHistory)} />
                 <CommandHistory entries={commandHistory} />
             </div>
             <div className="epoch-note">
@@ -1025,66 +1020,38 @@ const CommandHistory = ({ entries }: { entries: CommandHistoryEntry[] }) => {
     )
 }
 
-const getCommandHistoryEntries = (
-    commands: CockpitCommandRecord[],
-    outcomes: CommandOutcome[],
-    session: CockpitSession | undefined,
-): CommandHistoryEntry[] => {
-    if (session === undefined) {
-        return []
+const CommandOutcomeOverview = ({ summary }: { summary: CommandOutcomeSummary }) => {
+    if (summary.total === 0) {
+        return null
     }
 
-    const outcomesByCommandId = new Map(outcomes.map((outcome) => [outcome.commandId, outcome]))
-    const visibleCommandIds = new Set<string>()
-    const entries = commands
-        .filter((record) => {
-            const outcome = outcomesByCommandId.get(record.id)
-            return (
-                (record.command.sessionId === session.sessionId && record.command.sessionEpoch === session.sessionEpoch) ||
-                (outcome?.sessionId === session.sessionId && outcome.sessionEpoch === session.sessionEpoch)
-            )
-        })
-        .map((record): CommandHistoryEntry => {
-            const outcome = outcomesByCommandId.get(record.id)
-            const state = outcome?.status ?? (record.deliveredAt === null ? "queued" : "delivered")
-            const timestamp = outcome?.handledAt ?? record.deliveredAt ?? record.receivedAt
-            const detail = outcome?.reason ?? (record.deliveredAt === null ? "Waiting for Every Code" : "Claimed by Every Code")
-            visibleCommandIds.add(record.id)
+    const tone = summary.stale > 0 || summary.rejected > 0 ? "is-warning" : "is-success"
+    const latest = summary.latest
 
-            return {
-                id: record.id,
-                label: formatCommandKind(record.command.kind),
-                state,
-                timestamp,
-                detail,
-            }
-        })
-
-    const outcomeOnlyEntries = outcomes
-        .filter(
-            (outcome) =>
-                outcome.sessionId === session.sessionId &&
-                outcome.sessionEpoch === session.sessionEpoch &&
-                !visibleCommandIds.has(outcome.commandId),
-        )
-        .map(
-            (outcome): CommandHistoryEntry => ({
-                id: outcome.commandId,
-                label: formatCommandKind(outcome.commandKind),
-                state: outcome.status,
-                timestamp: outcome.handledAt,
-                detail: outcome.reason ?? "Outcome reported by Every Code",
-            }),
-        )
-
-    return [...entries, ...outcomeOnlyEntries].sort((left, right) => right.timestamp.localeCompare(left.timestamp)).slice(0, 5)
+    return (
+        <div className={`command-outcome-overview ${tone}`} aria-label="Command outcome summary">
+            <div className="command-outcome-metrics">
+                <span>
+                    <strong>{summary.total}</strong>
+                    retained
+                </span>
+                <span>
+                    <strong>{summary.rejected}</strong>
+                    rejected
+                </span>
+                <span>
+                    <strong>{summary.stale}</strong>
+                    stale
+                </span>
+            </div>
+            {latest === undefined ? null : (
+                <p>
+                    Latest: {latest.label} {latest.isCurrentEpoch ? "on current epoch" : "from previous epoch"}
+                </p>
+            )}
+        </div>
+    )
 }
-
-const formatCommandKind = (kind: SessionCommand["kind"]): string =>
-    kind
-        .split("_")
-        .map((part) => `${part[0]?.toUpperCase() ?? ""}${part.slice(1)}`)
-        .join(" ")
 
 const formatTime = (iso: string): string =>
     new Intl.DateTimeFormat("en", {

--- a/apps/web/src/cockpitData.test.ts
+++ b/apps/web/src/cockpitData.test.ts
@@ -6,6 +6,8 @@ import {
     cockpitFixtureSnapshot,
     createCockpitFixtureFromSnapshot,
     getAttentionSessions,
+    getCommandHistoryEntries,
+    getCommandOutcomeSummary,
     getOperatorAttentionSummary,
     getSessionDetailSummary,
     statusLabels,
@@ -165,5 +167,29 @@ describe("cockpit fake data", () => {
         })
         expect(summary.blockedCount).toBe(3)
         expect(summary.errorCount).toBe(0)
+    })
+
+    it("summarizes retained rejected command outcomes for the selected session", () => {
+        const session = cockpitFixture.sessions.find((candidate) => candidate.sessionId === "ce-delta")
+        expect(session).toBeDefined()
+        if (session === undefined) {
+            throw new Error("Expected ce-delta fixture session")
+        }
+
+        const history = getCommandHistoryEntries(cockpitFixture.commands, cockpitFixture.commandOutcomes, session)
+        const summary = getCommandOutcomeSummary(history)
+
+        expect(history).toHaveLength(1)
+        expect(history[0]).toMatchObject({
+            id: "command-delta-rejected",
+            state: "rejected",
+            isStale: true,
+            isCurrentEpoch: true,
+        })
+        expect(summary).toMatchObject({
+            total: 1,
+            rejected: 1,
+            stale: 1,
+        })
     })
 })

--- a/apps/web/src/cockpitData.ts
+++ b/apps/web/src/cockpitData.ts
@@ -55,6 +55,23 @@ export type SessionDetailSummary = {
     blockedCount: number
 }
 
+export type CommandHistoryEntry = {
+    id: string
+    label: string
+    state: "queued" | "delivered" | "accepted" | "rejected"
+    timestamp: string
+    detail: string
+    isStale: boolean
+    isCurrentEpoch: boolean
+}
+
+export type CommandOutcomeSummary = {
+    total: number
+    rejected: number
+    stale: number
+    latest: CommandHistoryEntry | undefined
+}
+
 export type OperatorAttentionKind = "approval" | "input" | "error" | "blocked" | "stale-command" | "rejected-command"
 
 export type OperatorAttentionItem = {
@@ -429,7 +446,17 @@ const cockpitFixtureSource: SourceCockpitFixture = {
             ],
         },
     ],
-    commandOutcomes: [],
+    commandOutcomes: [
+        {
+            commandId: "command-delta-rejected",
+            sessionId: "ce-delta",
+            sessionEpoch: "epoch-3",
+            commandKind: "continue_autonomously",
+            status: "rejected",
+            reason: "no active turn is ready to continue after stale epoch rejection",
+            handledAt: "2026-04-27T15:47:30.000Z",
+        },
+    ],
     commands: [],
     staleEvents: [],
 }
@@ -453,6 +480,10 @@ export const createCockpitFixtureEvents = (fixture: SourceCockpitFixture): Cockp
     ...fixture.requestedInputs.map<CockpitProjectionEvent>((input) => ({
         kind: "user_input_requested",
         input,
+    })),
+    ...fixture.commandOutcomes.map<CockpitProjectionEvent>((outcome) => ({
+        kind: "command_outcome",
+        outcome,
     })),
     ...fixture.sessions.map<CockpitProjectionEvent>((session) => ({
         kind: "session_status_changed",
@@ -603,6 +634,90 @@ export const getSessionDetailSummary = (session: CockpitSession): SessionDetailS
         blockedCount,
     }
 }
+
+export const getCommandHistoryEntries = (
+    commands: CockpitCommandRecord[],
+    outcomes: CommandOutcome[],
+    session: CockpitSession | undefined,
+): CommandHistoryEntry[] => {
+    if (session === undefined) {
+        return []
+    }
+
+    const outcomesByCommandId = new Map(outcomes.map((outcome) => [outcome.commandId, outcome]))
+    const visibleCommandIds = new Set<string>()
+    const entries = commands
+        .filter((record) => {
+            const outcome = outcomesByCommandId.get(record.id)
+            return (
+                (record.command.sessionId === session.sessionId && record.command.sessionEpoch === session.sessionEpoch) ||
+                (outcome?.sessionId === session.sessionId && isVisibleOutcomeForSession(outcome, session))
+            )
+        })
+        .map((record): CommandHistoryEntry => {
+            const outcome = outcomesByCommandId.get(record.id)
+            const state = outcome?.status ?? (record.deliveredAt === null ? "queued" : "delivered")
+            const timestamp = outcome?.handledAt ?? record.deliveredAt ?? record.receivedAt
+            const detail = outcome?.reason ?? (record.deliveredAt === null ? "Waiting for Every Code" : "Claimed by Every Code")
+            visibleCommandIds.add(record.id)
+
+            return {
+                id: record.id,
+                label: formatCommandKind(record.command.kind),
+                state,
+                timestamp,
+                detail,
+                isStale: isStaleCommandOutcome(outcome),
+                isCurrentEpoch:
+                    outcome?.sessionEpoch === session.sessionEpoch || record.command.sessionEpoch === session.sessionEpoch,
+            }
+        })
+
+    const outcomeOnlyEntries = outcomes
+        .filter(
+            (outcome) =>
+                outcome.sessionId === session.sessionId &&
+                isVisibleOutcomeForSession(outcome, session) &&
+                !visibleCommandIds.has(outcome.commandId),
+        )
+        .map(
+            (outcome): CommandHistoryEntry => ({
+                id: outcome.commandId,
+                label: formatCommandKind(outcome.commandKind),
+                state: outcome.status,
+                timestamp: outcome.handledAt,
+                detail: outcome.reason ?? "Outcome reported by Every Code",
+                isStale: isStaleCommandOutcome(outcome),
+                isCurrentEpoch: outcome.sessionEpoch === session.sessionEpoch,
+            }),
+        )
+
+    return [...entries, ...outcomeOnlyEntries].sort((left, right) => right.timestamp.localeCompare(left.timestamp)).slice(0, 5)
+}
+
+export const getCommandOutcomeSummary = (entries: CommandHistoryEntry[]): CommandOutcomeSummary => {
+    const rejected = entries.filter((entry) => entry.state === "rejected").length
+    const stale = entries.filter((entry) => entry.isStale).length
+
+    return {
+        total: entries.length,
+        rejected,
+        stale,
+        latest: entries.at(0),
+    }
+}
+
+const isVisibleOutcomeForSession = (outcome: CommandOutcome, session: CockpitSession): boolean =>
+    outcome.sessionEpoch === session.sessionEpoch || outcome.status === "rejected" || isStaleCommandOutcome(outcome)
+
+const isStaleCommandOutcome = (outcome: CommandOutcome | undefined): boolean =>
+    outcome?.reason?.toLowerCase().includes("stale") ?? false
+
+const formatCommandKind = (kind: SessionCommand["kind"]): string =>
+    kind
+        .split("_")
+        .map((part) => `${part[0]?.toUpperCase() ?? ""}${part.slice(1)}`)
+        .join(" ")
 
 const emptyTurnStepSummary = (): TurnStepSummary => ({
     message: 0,

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1350,6 +1350,49 @@ legend {
     margin-top: 10px;
 }
 
+.command-outcome-overview {
+    display: grid;
+    gap: 6px;
+    margin-top: 10px;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    padding: 8px;
+    background: var(--bg-base);
+}
+
+.command-outcome-overview.is-warning {
+    border-color: var(--warning-border);
+    background: var(--warning-bg-soft);
+}
+
+.command-outcome-overview.is-success {
+    border-color: var(--success-border);
+    background: var(--success-bg-soft);
+}
+
+.command-outcome-metrics {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.command-outcome-metrics span {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.54);
+    padding: 3px 7px;
+    color: var(--fg-2);
+    font-size: 11px;
+    font-weight: 700;
+}
+
+.command-outcome-metrics strong {
+    color: var(--fg-1);
+    font-size: 12px;
+}
+
 .command-history-row {
     display: grid;
     grid-template-columns: 74px minmax(0, 1fr);

--- a/docs/every-code-integration.md
+++ b/docs/every-code-integration.md
@@ -97,6 +97,9 @@ It should keep the next action visible and make transport health explicit:
 - Session detail starts with a current-turn summary that shows the active or
   latest turn title, summary, total projected steps, blocked/error signals, and
   step-kind counts before lower-priority metadata and history.
+- Session control includes a compact command outcome summary above recent
+  command history so retained rejected/stale outcomes remain visible without
+  taking over the pending-work surface.
 - A compact state banner explains fixture mode, first live connection, broker
   fallback/reconnect, healthy-but-empty live broker snapshots, and retained
   stale-event evidence.


### PR DESCRIPTION
## Summary
- derive command history and outcome summary state in the cockpit data layer
- show retained/rejected/stale outcome counts above recent command history
- seed fixture coverage for a blocked session with retained rejected/stale command context
- document the session-control outcome summary surface

## Validation
- pnpm lint:dry-run
- pnpm validate
- pnpm smoke:cockpit:web
- pnpm smoke:cockpit:retained-pruned
- pnpm smoke:cockpit:turns
- browser UI review at 1024x768 and 390x844