### PR TITLE
Add local broker auth boundary

### DIFF
--- a/apps/web/src/cockpitCommands.ts
+++ b/apps/web/src/cockpitCommands.ts
@@ -5,6 +5,11 @@ import type { CockpitTransportStatus } from "./cockpitTransport"
 
 type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
 
+const configuredAuthToken = (() => {
+    const authToken: unknown = import.meta.env.VITE_COCKPIT_AUTH_TOKEN
+    return typeof authToken === "string" ? normalizeAuthToken(authToken) : null
+})()
+
 export const postCockpitCommand = async (
     transportUrl: string,
     command: SessionCommand,
@@ -16,6 +21,7 @@ export const postCockpitCommand = async (
         headers: {
             accept: "application/json",
             "content-type": "application/json",
+            ...createAuthHeaders(configuredAuthToken),
         },
         body: JSON.stringify({ command }),
     })
@@ -40,6 +46,7 @@ export const fetchCockpitCommands = async (
         cache: "no-store",
         headers: {
             accept: "application/json",
+            ...createAuthHeaders(configuredAuthToken),
         },
     })
 
@@ -56,6 +63,15 @@ export const fetchCockpitCommands = async (
 }
 
 export const createCommandUrl = (transportUrl: string): string => `${transportUrl.replace(/\/+$/, "")}/commands`
+
+function normalizeAuthToken(authToken: string): string | null {
+    const normalized = authToken.trim()
+    return normalized === "" ? null : normalized
+}
+
+function createAuthHeaders(authToken: string | null): Record<string, string> {
+    return authToken === null ? {} : { authorization: `Bearer ${authToken}` }
+}
 
 export const canPostCockpitCommand = (
     transport: CockpitTransportStatus,

--- a/apps/web/src/cockpitTransport.ts
+++ b/apps/web/src/cockpitTransport.ts
@@ -57,6 +57,10 @@ const configuredPollIntervalMs = (() => {
     const pollIntervalMs: unknown = import.meta.env.VITE_COCKPIT_POLL_INTERVAL_MS
     return typeof pollIntervalMs === "string" ? normalizePollIntervalMs(pollIntervalMs) : null
 })()
+const configuredAuthToken = (() => {
+    const authToken: unknown = import.meta.env.VITE_COCKPIT_AUTH_TOKEN
+    return typeof authToken === "string" ? normalizeAuthToken(authToken) : null
+})()
 
 export const useCockpitView = (options: UseCockpitViewOptions = {}): CockpitViewState => {
     const transportUrl = normalizeTransportUrl(options.transportUrl) ?? configuredTransportUrl
@@ -202,6 +206,7 @@ export const fetchCockpitSnapshot = async (
         cache: "no-store",
         headers: {
             accept: "application/json",
+            ...createAuthHeaders(configuredAuthToken),
         },
     })
 
@@ -219,6 +224,15 @@ export const fetchCockpitSnapshot = async (
 }
 
 export const createSnapshotUrl = (transportUrl: string): string => `${transportUrl.replace(/\/+$/, "")}/snapshot`
+
+function normalizeAuthToken(authToken: string): string | null {
+    const normalized = authToken.trim()
+    return normalized === "" ? null : normalized
+}
+
+function createAuthHeaders(authToken: string | null): Record<string, string> {
+    return authToken === null ? {} : { authorization: `Bearer ${authToken}` }
+}
 
 export function normalizeTransportUrl(transportUrl: string | undefined): string | null {
     const normalized = transportUrl?.trim()

--- a/docs/every-code-integration.md
+++ b/docs/every-code-integration.md
@@ -63,6 +63,10 @@ Every Code adapter that consumes them:
 - the broker persists local state to `.code-everywhere/cockpit-broker.json` by
   default; pass `--memory` for an ephemeral run or `--data-file <path>` to use a
   different file
+- loopback-only broker usage remains tokenless by default for local development
+- when `--auth-token <token>` or `CODE_EVERYWHERE_AUTH_TOKEN` is set, all broker
+  routes require `Authorization: Bearer <token>` or `X-Code-Everywhere-Token`
+- binding beyond loopback, such as `--host 0.0.0.0`, requires an auth token
 - web and native clients enqueue operator actions with `POST /commands`
 - local adapters claim undelivered work with `POST /commands/claim`
 - `POST /commands/claim` accepts an optional `sessionId` filter and marks
@@ -73,6 +77,8 @@ Every Code adapter that consumes them:
   from `@code-everywhere/server/http-client`
 - adapter code should publish session events with the typed `postCockpitEvents`
   helper exported from the same module
+- web clients pass broker auth with `VITE_COCKPIT_AUTH_TOKEN` when the broker is
+  started with a token
 
 The Every Code HTTP remote-inbox adapter claims commands for its active
 `sessionId`, translates `SessionCommand` values into the runtime's existing

--- a/packages/server/src/cli.test.ts
+++ b/packages/server/src/cli.test.ts
@@ -29,19 +29,28 @@ describe("cockpit HTTP server CLI", () => {
             host: "127.0.0.1",
             port: 4789,
             dataFile: ".code-everywhere/cockpit-broker.json",
+            authToken: null,
             help: false,
         })
         expect(
-            parseCockpitServerArgs(["--host", "0.0.0.0", "--port=4900", "--data-file", "/tmp/cockpit.json"], {
-                CODE_EVERYWHERE_HOST: "127.0.0.1",
-                CODE_EVERYWHERE_PORT: "nope",
-                CODE_EVERYWHERE_DATA_FILE: "/tmp/env-cockpit.json",
-            }),
+            parseCockpitServerArgs(
+                ["--host", "0.0.0.0", "--port=4900", "--data-file", "/tmp/cockpit.json", "--auth-token", "arg-secret"],
+                {
+                    CODE_EVERYWHERE_HOST: "127.0.0.1",
+                    CODE_EVERYWHERE_PORT: "nope",
+                    CODE_EVERYWHERE_DATA_FILE: "/tmp/env-cockpit.json",
+                    CODE_EVERYWHERE_AUTH_TOKEN: "env-secret",
+                },
+            ),
         ).toEqual({
             host: "0.0.0.0",
             port: 4900,
             dataFile: "/tmp/cockpit.json",
+            authToken: "arg-secret",
             help: false,
+        })
+        expect(parseCockpitServerArgs([], { CODE_EVERYWHERE_AUTH_TOKEN: "env-secret" })).toMatchObject({
+            authToken: "env-secret",
         })
         expect(parseCockpitServerArgs(["--memory"], {})).toMatchObject({ dataFile: null })
         expect(parseCockpitServerArgs(["--", "--help"], {})).toMatchObject({ help: true })
@@ -53,6 +62,7 @@ describe("cockpit HTTP server CLI", () => {
         expect(() => parseCockpitServerArgs(["--port", "nope"], {})).toThrow(CockpitServerCliError)
         expect(() => parseCockpitServerArgs(["--host"], {})).toThrow("--host requires a value")
         expect(() => parseCockpitServerArgs(["--data-file"], {})).toThrow("--data-file requires a value")
+        expect(() => parseCockpitServerArgs(["--auth-token"], {})).toThrow("--auth-token requires a value")
         expect(() => parseCockpitServerArgs(["--host", "--port", "4900"], {})).toThrow("--host requires a value")
         expect(() => parseCockpitServerArgs(["--port", "--host", "127.0.0.1"], {})).toThrow("--port requires a value")
         expect(() => parseCockpitServerArgs(["--wat"], {})).toThrow("Unknown option: --wat")
@@ -84,6 +94,20 @@ describe("cockpit HTTP server CLI", () => {
                     resolve()
                 })
             })
+        }
+    })
+
+    it("requires auth token when binding beyond loopback", async () => {
+        await expect(startCockpitHttpServer({ host: "0.0.0.0", port: 0, dataFile: null })).rejects.toThrow(
+            "--auth-token or CODE_EVERYWHERE_AUTH_TOKEN is required when binding beyond loopback",
+        )
+
+        const running = await startCockpitHttpServer({ host: "0.0.0.0", port: 0, dataFile: null, authToken: "test-secret" })
+        try {
+            const response = await sendJson(running.url, "GET", "/snapshot")
+            expect(response.statusCode).toBe(401)
+        } finally {
+            await closeServer(running.server)
         }
     })
 

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -9,6 +9,7 @@ export type CockpitServerCliOptions = {
     host: string
     port: number
     dataFile: string | null
+    authToken: string | null
     help: boolean
 }
 
@@ -26,12 +27,13 @@ export class CockpitServerCliError extends Error {}
 export const formatCockpitServerHelp = (): string => `Code Everywhere cockpit HTTP server
 
 Usage:
-  pnpm cockpit:server [--host 127.0.0.1] [--port 4789] [--data-file .code-everywhere/cockpit-broker.json]
+  pnpm cockpit:server [--host 127.0.0.1] [--port 4789] [--data-file .code-everywhere/cockpit-broker.json] [--auth-token <token>]
 
 Options:
   --host <host>            Bind address. Defaults to CODE_EVERYWHERE_HOST or ${defaultHost}.
   --port <port>            Bind port. Defaults to CODE_EVERYWHERE_PORT or ${String(defaultPort)}.
   --data-file <path>       Persistence file. Defaults to CODE_EVERYWHERE_DATA_FILE or ${defaultDataFile}.
+  --auth-token <token>      Require token auth. Defaults to CODE_EVERYWHERE_AUTH_TOKEN.
   --memory                 Disable file persistence for this run.
   -h, --help               Show this help.
 `
@@ -42,6 +44,7 @@ export const parseCockpitServerArgs = (args: readonly string[], variables: NodeJ
             host: defaultHost,
             port: defaultPort,
             dataFile: defaultDataFile,
+            authToken: null,
             help: true,
         }
     }
@@ -49,6 +52,7 @@ export const parseCockpitServerArgs = (args: readonly string[], variables: NodeJ
     let host = normalizeHost(variables.CODE_EVERYWHERE_HOST) ?? defaultHost
     let port: number | undefined
     let dataFile: string | null = normalizeValue(variables.CODE_EVERYWHERE_DATA_FILE) ?? defaultDataFile
+    let authToken: string | null = normalizeValue(variables.CODE_EVERYWHERE_AUTH_TOKEN) ?? null
     let help = false
 
     for (let index = 0; index < args.length; index += 1) {
@@ -101,6 +105,17 @@ export const parseCockpitServerArgs = (args: readonly string[], variables: NodeJ
             continue
         }
 
+        if (arg === "--auth-token") {
+            authToken = readOptionValue(args, index, "--auth-token")
+            index += 1
+            continue
+        }
+
+        if (arg?.startsWith("--auth-token=")) {
+            authToken = requireNonEmptyValue(arg.slice("--auth-token=".length), "--auth-token")
+            continue
+        }
+
         throw new CockpitServerCliError(`Unknown option: ${arg ?? ""}`)
     }
 
@@ -108,6 +123,7 @@ export const parseCockpitServerArgs = (args: readonly string[], variables: NodeJ
         host,
         port: port ?? parsePort(variables.CODE_EVERYWHERE_PORT, "CODE_EVERYWHERE_PORT") ?? defaultPort,
         dataFile,
+        authToken,
         help,
     }
 }
@@ -121,11 +137,16 @@ export const cockpitServerUrl = (host: string, port: number): string => {
 }
 
 export const startCockpitHttpServer = async (
-    options: Pick<CockpitServerCliOptions, "host" | "port"> & { dataFile?: string | null },
+    options: Pick<CockpitServerCliOptions, "host" | "port"> & { authToken?: string | null; dataFile?: string | null },
 ): Promise<RunningCockpitServer> => {
+    const authToken = normalizeValue(options.authToken ?? undefined) ?? null
+    if (!isLoopbackHost(options.host) && authToken === null) {
+        throw new CockpitServerCliError("--auth-token or CODE_EVERYWHERE_AUTH_TOKEN is required when binding beyond loopback")
+    }
+
     const stores =
         options.dataFile === undefined || options.dataFile === null ? undefined : createPersistentCockpitStores(options.dataFile)
-    const server = createCockpitHttpServer(stores)
+    const server = createCockpitHttpServer({ ...(stores ?? {}), authToken })
     await new Promise<void>((resolve, reject) => {
         const onError = (error: Error) => {
             server.off("listening", onListening)
@@ -167,6 +188,9 @@ export const runCockpitServerCli = async (
         if (options.dataFile !== null) {
             stdout.write(`Persisting broker state to ${options.dataFile}\n`)
         }
+        if (options.authToken !== null) {
+            stdout.write("Broker auth token enabled.\n")
+        }
         stdout.write(`Use VITE_COCKPIT_HTTP_URL=${running.url} for the web cockpit.\n`)
         return 0
     } catch (error: unknown) {
@@ -182,6 +206,11 @@ const normalizeHost = (host: string | undefined): string | undefined => {
 const normalizeValue = (value: string | undefined): string | undefined => {
     const normalized = value?.trim()
     return normalized === undefined || normalized === "" ? undefined : normalized
+}
+
+const isLoopbackHost = (host: string): boolean => {
+    const normalized = host.trim().toLowerCase()
+    return normalized === "localhost" || normalized === "::1" || normalized === "[::1]" || normalized.startsWith("127.")
 }
 
 const readOptionValue = (args: readonly string[], index: number, option: string): string =>

--- a/packages/server/src/http-client.ts
+++ b/packages/server/src/http-client.ts
@@ -6,6 +6,7 @@ type FetchLike = typeof globalThis.fetch
 
 export type ClaimCockpitCommandsOptions = {
     sessionId?: string
+    authToken?: string
     fetch?: FetchLike
 }
 
@@ -19,6 +20,7 @@ export const claimCockpitCommands = async (
         headers: {
             accept: "application/json",
             "content-type": "application/json",
+            ...createAuthHeaders(options.authToken),
         },
         body: JSON.stringify(options.sessionId === undefined ? {} : { sessionId: options.sessionId }),
     })
@@ -39,6 +41,7 @@ export const postCockpitEvents = async (
     transportUrl: string,
     events: CockpitProjectionEvent | CockpitProjectionEvent[],
     fetchImpl: FetchLike = globalThis.fetch,
+    authToken?: string,
 ): Promise<CockpitIngestionSnapshot> => {
     const response = await fetchImpl(createCockpitEventsUrl(transportUrl), {
         method: "POST",
@@ -46,6 +49,7 @@ export const postCockpitEvents = async (
         headers: {
             accept: "application/json",
             "content-type": "application/json",
+            ...createAuthHeaders(authToken),
         },
         body: JSON.stringify(Array.isArray(events) ? { events } : { event: events }),
     })
@@ -65,6 +69,11 @@ export const postCockpitEvents = async (
 export const createCommandClaimUrl = (transportUrl: string): string => createLocalHttpUrl(transportUrl, "commands/claim")
 
 export const createCockpitEventsUrl = (transportUrl: string): string => createLocalHttpUrl(transportUrl, "events")
+
+const createAuthHeaders = (authToken: string | undefined): Record<string, string> => {
+    const normalized = authToken?.trim()
+    return normalized === undefined || normalized === "" ? {} : { authorization: `Bearer ${normalized}` }
+}
 
 const createLocalHttpUrl = (transportUrl: string, path: string): string => {
     const url = new URL(transportUrl)

--- a/packages/server/src/http.test.ts
+++ b/packages/server/src/http.test.ts
@@ -87,6 +87,45 @@ describe("cockpit HTTP transport", () => {
         })
     })
 
+    it("requires configured auth token on broker routes", async () => {
+        const protectedServer = createCockpitHttpServer({ authToken: "test-secret" })
+        await new Promise<void>((resolve) => {
+            protectedServer.listen(0, "127.0.0.1", resolve)
+        })
+        const address = protectedServer.address() as AddressInfo
+        const protectedBaseUrl = `http://127.0.0.1:${String(address.port)}`
+
+        try {
+            await expect(sendJson(protectedBaseUrl, "GET", "/snapshot")).resolves.toMatchObject({
+                statusCode: 401,
+                body: { error: "Unauthorized" },
+            })
+
+            const bearerResponse = await sendJson(protectedBaseUrl, "GET", "/snapshot", undefined, {
+                authorization: "Bearer test-secret",
+            })
+            expect(bearerResponse.statusCode).toBe(200)
+
+            const headerResponse = await sendJson(protectedBaseUrl, "GET", "/snapshot", undefined, {
+                "x-code-everywhere-token": "test-secret",
+            })
+            expect(headerResponse.statusCode).toBe(200)
+            expect(headerResponse.headers["access-control-allow-headers"]).toContain("authorization")
+            expect(headerResponse.headers["access-control-allow-headers"]).toContain("x-code-everywhere-token")
+        } finally {
+            await new Promise<void>((resolve, reject) => {
+                protectedServer.close((error) => {
+                    if (error !== undefined) {
+                        reject(error)
+                        return
+                    }
+
+                    resolve()
+                })
+            })
+        }
+    })
+
     it("ingests a single event and event array", async () => {
         const helloResponse = await sendJson(baseUrl, "POST", "/events", {
             event: {
@@ -485,10 +524,21 @@ type TestResponse = {
     body: unknown
 }
 
-const sendJson = (baseUrl: string, method: string, path: string, body?: unknown): Promise<TestResponse> =>
-    sendRaw(baseUrl, method, path, body === undefined ? undefined : JSON.stringify(body))
+const sendJson = (
+    baseUrl: string,
+    method: string,
+    path: string,
+    body?: unknown,
+    headers?: Record<string, string>,
+): Promise<TestResponse> => sendRaw(baseUrl, method, path, body === undefined ? undefined : JSON.stringify(body), headers)
 
-const sendRaw = (baseUrl: string, method: string, path: string, body?: string): Promise<TestResponse> => {
+const sendRaw = (
+    baseUrl: string,
+    method: string,
+    path: string,
+    body?: string,
+    headers?: Record<string, string>,
+): Promise<TestResponse> => {
     const url = new URL(path, baseUrl)
     const options: RequestOptions = {
         hostname: url.hostname,
@@ -497,6 +547,7 @@ const sendRaw = (baseUrl: string, method: string, path: string, body?: string): 
         method,
         headers: {
             "content-type": "application/json",
+            ...headers,
         },
     }
 

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -30,6 +30,7 @@ export type CockpitHttpHandlerOptions = {
     store?: CockpitEventStore
     commandStore?: CockpitCommandStore
     maxBodyBytes?: number
+    authToken?: string | null
 }
 
 export type CockpitHttpServerOptions = CockpitHttpHandlerOptions
@@ -75,9 +76,10 @@ export const createCockpitHttpHandler = (options: CockpitHttpHandlerOptions = {}
     const store = options.store ?? createCockpitEventStore()
     const commandStore = options.commandStore ?? createCockpitCommandStore()
     const maxBodyBytes = options.maxBodyBytes ?? defaultMaxBodyBytes
+    const authToken = normalizeAuthToken(options.authToken)
 
     return (request: IncomingMessage, response: ServerResponse): void => {
-        void routeRequest(request, response, store, commandStore, maxBodyBytes).catch((error: unknown) => {
+        void routeRequest(request, response, store, commandStore, maxBodyBytes, authToken).catch((error: unknown) => {
             if (error instanceof HttpInputError) {
                 writeJson(response, error.statusCode, { error: error.message })
                 return
@@ -97,6 +99,7 @@ const routeRequest = async (
     store: CockpitEventStore,
     commandStore: CockpitCommandStore,
     maxBodyBytes: number,
+    authToken: string | null,
 ): Promise<void> => {
     setCorsHeaders(response)
 
@@ -107,6 +110,12 @@ const routeRequest = async (
     }
 
     const url = parseRequestUrl(request)
+
+    if (!isAuthorizedRequest(request, authToken)) {
+        response.setHeader("www-authenticate", 'Bearer realm="code-everywhere"')
+        writeJson(response, 401, { error: "Unauthorized" })
+        return
+    }
 
     if (url.pathname === "/snapshot") {
         if (request.method !== "GET") {
@@ -195,6 +204,34 @@ const routeRequest = async (
 }
 
 const parseRequestUrl = (request: IncomingMessage): URL => new URL(request.url ?? "/", "http://localhost")
+
+const normalizeAuthToken = (token: string | null | undefined): string | null => {
+    const normalized = token?.trim()
+    return normalized === undefined || normalized === "" ? null : normalized
+}
+
+const isAuthorizedRequest = (request: IncomingMessage, authToken: string | null): boolean => {
+    if (authToken === null) {
+        return true
+    }
+
+    return getBearerToken(request) === authToken || getHeaderValue(request, "x-code-everywhere-token") === authToken
+}
+
+const getBearerToken = (request: IncomingMessage): string | null => {
+    const authorization = getHeaderValue(request, "authorization")
+    const match = /^Bearer\s+(.+)$/i.exec(authorization)
+    return match?.[1]?.trim() ?? null
+}
+
+const getHeaderValue = (request: IncomingMessage, name: string): string => {
+    const value = request.headers[name]
+    if (Array.isArray(value)) {
+        return value[0]?.trim() ?? ""
+    }
+
+    return value?.trim() ?? ""
+}
 
 const readJsonBody = async (request: IncomingMessage, maxBodyBytes: number, allowEmpty = false): Promise<unknown> => {
     const chunks: Uint8Array[] = []
@@ -510,7 +547,7 @@ const writeMethodNotAllowed = (response: ServerResponse, allow: string): void =>
 const setCorsHeaders = (response: ServerResponse): void => {
     response.setHeader("access-control-allow-origin", "*")
     response.setHeader("access-control-allow-methods", "GET, POST, OPTIONS")
-    response.setHeader("access-control-allow-headers", "content-type, accept")
+    response.setHeader("access-control-allow-headers", "authorization, content-type, accept, x-code-everywhere-token")
 }
 
 const writeJson = (response: ServerResponse, statusCode: number, payload: JsonResponse): void => {


### PR DESCRIPTION
## Summary
- add optional token auth to the local broker and require it for non-loopback binds
- accept bearer or X-Code-Everywhere-Token auth headers on protected broker routes
- pass VITE_COCKPIT_AUTH_TOKEN from the web cockpit when configured
- extend typed HTTP client helpers for authenticated event publish/command claim requests
- document the local broker trust boundary

## Validation
- pnpm lint:dry-run
- pnpm validate
- pnpm smoke:cockpit:web
- pnpm smoke:cockpit:retained-pruned
- pnpm smoke:cockpit:turns