### PR TITLE
Fix cockpit retained evidence summaries

### DIFF
--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+
+import { getCockpitStateSurface } from "./App"
+
+describe("cockpit state surface", () => {
+    it("keeps retained stale-event evidence visible before empty live-session state", () => {
+        const surface = getCockpitStateSurface(
+            {
+                sessions: [],
+                staleEvents: [
+                    {
+                        eventKind: "turn_step_added",
+                        sessionId: "session-1",
+                        eventEpoch: "epoch-1",
+                        currentEpoch: "epoch-2",
+                        receivedAt: "2026-04-27T16:10:00.000Z",
+                    },
+                ],
+            },
+            {
+                mode: "live",
+                url: "http://127.0.0.1:4789",
+                updatedAt: "2026-04-27T16:10:00.000Z",
+                error: null,
+            },
+        )
+
+        expect(surface).toMatchObject({
+            tone: "warning",
+            title: "Stale event evidence retained",
+        })
+    })
+})

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -174,6 +174,7 @@ export const App = () => {
         activePendingItemId === null || selectedApproval !== undefined ? (selectedApproval ?? sessionApprovals[0]) : undefined
     const activeInput = activePendingItemId === null || selectedInput !== undefined ? (selectedInput ?? sessionInputs[0]) : undefined
     const activeCommandHistory = getCommandHistoryEntries(cockpit.commands, cockpit.commandOutcomes, activeSession)
+    const activeCommandOutcomeSummary = getCommandOutcomeSummary(cockpit.commands, cockpit.commandOutcomes, activeSession)
     const reply = getDraftValue(replyDrafts, activeSession?.sessionId)
     const inputAnswerValues = getRequestedInputAnswerValues(inputAnswerDrafts, activeInput)
     const inputNote = getRequestedInputNoteValue(inputAnswerDrafts, activeInput)
@@ -285,6 +286,7 @@ export const App = () => {
                                 setInputNote={setInputNote}
                                 commandLog={commandLog}
                                 commandHistory={activeCommandHistory}
+                                commandOutcomeSummary={activeCommandOutcomeSummary}
                                 dispatchCommand={dispatchCommand}
                             />
                         </>
@@ -608,6 +610,7 @@ type ActionRailProps = {
     setInputNote: (value: string) => void
     commandLog: string
     commandHistory: CommandHistoryEntry[]
+    commandOutcomeSummary: CommandOutcomeSummary
     dispatchCommand: (label: string, command: SessionCommand) => void
 }
 
@@ -621,6 +624,7 @@ const ActionRail = ({
     setInputNote,
     commandLog,
     commandHistory,
+    commandOutcomeSummary,
     dispatchCommand,
 }: ActionRailProps) => (
     <aside className="action-rail" aria-label="Pending work and actions">
@@ -681,7 +685,7 @@ const ActionRail = ({
             <div className="mock-log" aria-live="polite">
                 <span>Command status</span>
                 <p>{commandLog}</p>
-                <CommandOutcomeOverview summary={getCommandOutcomeSummary(commandHistory)} />
+                <CommandOutcomeOverview summary={commandOutcomeSummary} />
                 <CommandHistory entries={commandHistory} />
             </div>
             <div className="epoch-note">
@@ -912,7 +916,7 @@ const emptySessionDetailCopy = (transport: CockpitTransportStatus): string => {
     }
 }
 
-const getCockpitStateSurface = (
+export const getCockpitStateSurface = (
     cockpit: { sessions: CockpitSession[]; staleEvents: unknown[] },
     transport: CockpitTransportStatus,
 ): CockpitStateSurface | null => {
@@ -940,19 +944,19 @@ const getCockpitStateSurface = (
         }
     }
 
-    if (cockpit.sessions.length === 0) {
-        return {
-            tone: "success",
-            title: "No live sessions",
-            detail: "The broker is healthy, but no trusted Every Code sessions have published a snapshot yet.",
-        }
-    }
-
     if (cockpit.staleEvents.length > 0) {
         return {
             tone: "warning",
             title: "Stale event evidence retained",
             detail: `${String(cockpit.staleEvents.length)} stale epoch ${cockpit.staleEvents.length === 1 ? "event" : "events"} kept for operator review.`,
+        }
+    }
+
+    if (cockpit.sessions.length === 0) {
+        return {
+            tone: "success",
+            title: "No live sessions",
+            detail: "The broker is healthy, but no trusted Every Code sessions have published a snapshot yet.",
         }
     }
 

--- a/apps/web/src/cockpitData.test.ts
+++ b/apps/web/src/cockpitData.test.ts
@@ -1,3 +1,4 @@
+import type { CommandOutcome } from "@code-everywhere/contracts"
 import { describe, expect, it } from "vitest"
 
 import {
@@ -177,7 +178,7 @@ describe("cockpit fake data", () => {
         }
 
         const history = getCommandHistoryEntries(cockpitFixture.commands, cockpitFixture.commandOutcomes, session)
-        const summary = getCommandOutcomeSummary(history)
+        const summary = getCommandOutcomeSummary(cockpitFixture.commands, cockpitFixture.commandOutcomes, session)
 
         expect(history).toHaveLength(1)
         expect(history[0]).toMatchObject({
@@ -188,6 +189,49 @@ describe("cockpit fake data", () => {
         })
         expect(summary).toMatchObject({
             total: 1,
+            rejected: 1,
+            stale: 1,
+        })
+    })
+
+    it("summarizes all retained command outcomes, not just the five visible rows", () => {
+        const session = cockpitFixture.sessions.find((candidate) => candidate.sessionId === "ce-delta")
+        expect(session).toBeDefined()
+        if (session === undefined) {
+            throw new Error("Expected ce-delta fixture session")
+        }
+
+        const outcomes: CommandOutcome[] = [
+            ...Array.from(
+                { length: 5 },
+                (_, index): CommandOutcome => ({
+                    commandId: `command-visible-${String(index + 1)}`,
+                    sessionId: session.sessionId,
+                    sessionEpoch: session.sessionEpoch,
+                    commandKind: "status_request",
+                    status: "accepted",
+                    reason: null,
+                    handledAt: `2026-04-27T15:5${String(index)}:00.000Z`,
+                }),
+            ),
+            {
+                commandId: "command-hidden-stale",
+                sessionId: session.sessionId,
+                sessionEpoch: session.sessionEpoch,
+                commandKind: "continue_autonomously",
+                status: "rejected",
+                reason: "stale command retained for review",
+                handledAt: "2026-04-27T15:40:00.000Z",
+            },
+        ]
+
+        const history = getCommandHistoryEntries([], outcomes, session)
+        const summary = getCommandOutcomeSummary([], outcomes, session)
+
+        expect(history).toHaveLength(5)
+        expect(history.some((entry) => entry.id === "command-hidden-stale")).toBe(false)
+        expect(summary).toMatchObject({
+            total: 6,
             rejected: 1,
             stale: 1,
         })

--- a/apps/web/src/cockpitData.ts
+++ b/apps/web/src/cockpitData.ts
@@ -640,6 +640,31 @@ export const getCommandHistoryEntries = (
     outcomes: CommandOutcome[],
     session: CockpitSession | undefined,
 ): CommandHistoryEntry[] => {
+    return getRetainedCommandHistoryEntries(commands, outcomes, session).slice(0, 5)
+}
+
+export const getCommandOutcomeSummary = (
+    commands: CockpitCommandRecord[],
+    outcomes: CommandOutcome[],
+    session: CockpitSession | undefined,
+): CommandOutcomeSummary => {
+    const entries = getRetainedCommandHistoryEntries(commands, outcomes, session)
+    const rejected = entries.filter((entry) => entry.state === "rejected").length
+    const stale = entries.filter((entry) => entry.isStale).length
+
+    return {
+        total: entries.length,
+        rejected,
+        stale,
+        latest: entries[0],
+    }
+}
+
+const getRetainedCommandHistoryEntries = (
+    commands: CockpitCommandRecord[],
+    outcomes: CommandOutcome[],
+    session: CockpitSession | undefined,
+): CommandHistoryEntry[] => {
     if (session === undefined) {
         return []
     }
@@ -692,19 +717,7 @@ export const getCommandHistoryEntries = (
             }),
         )
 
-    return [...entries, ...outcomeOnlyEntries].sort((left, right) => right.timestamp.localeCompare(left.timestamp)).slice(0, 5)
-}
-
-export const getCommandOutcomeSummary = (entries: CommandHistoryEntry[]): CommandOutcomeSummary => {
-    const rejected = entries.filter((entry) => entry.state === "rejected").length
-    const stale = entries.filter((entry) => entry.isStale).length
-
-    return {
-        total: entries.length,
-        rejected,
-        stale,
-        latest: entries.at(0),
-    }
+    return [...entries, ...outcomeOnlyEntries].sort((left, right) => right.timestamp.localeCompare(left.timestamp))
 }
 
 const isVisibleOutcomeForSession = (outcome: CommandOutcome, session: CockpitSession): boolean =>


### PR DESCRIPTION
## Summary
- compute command outcome summary from all retained entries while keeping the visible history capped
- show retained stale-event evidence before the empty live-session state
- add regressions for both cockpit accuracy cases flagged by review

## Validation
- pnpm lint:dry-run
- pnpm --filter @code-everywhere/web test -- App.test.ts cockpitData.test.ts
- pnpm validate
- pnpm smoke:cockpit:web
- pnpm smoke:cockpit:retained-pruned
- pnpm smoke:cockpit:turns