### PR TITLE
Fix auth token and stale command regressions

### DIFF
--- a/apps/web/src/cockpitData.test.ts
+++ b/apps/web/src/cockpitData.test.ts
@@ -87,10 +87,10 @@ describe("cockpit fake data", () => {
                 {
                     commandId: "command-stale",
                     sessionId: "ce-alpha",
-                    sessionEpoch: "epoch-34",
+                    sessionEpoch: "epoch-33",
                     commandKind: "approval_decision",
                     status: "rejected",
-                    reason: "stale session scope: command targeted an old epoch",
+                    reason: "command targeted an old epoch",
                     handledAt: "2026-04-27T16:06:00.000Z",
                 },
                 {
@@ -184,13 +184,13 @@ describe("cockpit fake data", () => {
         expect(history[0]).toMatchObject({
             id: "command-delta-rejected",
             state: "rejected",
-            isStale: true,
+            isStale: false,
             isCurrentEpoch: true,
         })
         expect(summary).toMatchObject({
             total: 1,
             rejected: 1,
-            stale: 1,
+            stale: 0,
         })
     })
 
@@ -217,10 +217,10 @@ describe("cockpit fake data", () => {
             {
                 commandId: "command-hidden-stale",
                 sessionId: session.sessionId,
-                sessionEpoch: session.sessionEpoch,
+                sessionEpoch: "epoch-2",
                 commandKind: "continue_autonomously",
                 status: "rejected",
-                reason: "stale command retained for review",
+                reason: "command retained for review",
                 handledAt: "2026-04-27T15:40:00.000Z",
             },
         ]

--- a/apps/web/src/cockpitData.ts
+++ b/apps/web/src/cockpitData.ts
@@ -692,7 +692,7 @@ const getRetainedCommandHistoryEntries = (
                 state,
                 timestamp,
                 detail,
-                isStale: isStaleCommandOutcome(outcome),
+                isStale: isStaleCommandOutcome(outcome, session),
                 isCurrentEpoch:
                     outcome?.sessionEpoch === session.sessionEpoch || record.command.sessionEpoch === session.sessionEpoch,
             }
@@ -712,7 +712,7 @@ const getRetainedCommandHistoryEntries = (
                 state: outcome.status,
                 timestamp: outcome.handledAt,
                 detail: outcome.reason ?? "Outcome reported by Every Code",
-                isStale: isStaleCommandOutcome(outcome),
+                isStale: isStaleCommandOutcome(outcome, session),
                 isCurrentEpoch: outcome.sessionEpoch === session.sessionEpoch,
             }),
         )
@@ -721,10 +721,18 @@ const getRetainedCommandHistoryEntries = (
 }
 
 const isVisibleOutcomeForSession = (outcome: CommandOutcome, session: CockpitSession): boolean =>
-    outcome.sessionEpoch === session.sessionEpoch || outcome.status === "rejected" || isStaleCommandOutcome(outcome)
+    outcome.sessionEpoch === session.sessionEpoch || outcome.status === "rejected" || isStaleCommandOutcome(outcome, session)
 
-const isStaleCommandOutcome = (outcome: CommandOutcome | undefined): boolean =>
-    outcome?.reason?.toLowerCase().includes("stale") ?? false
+const isStaleCommandOutcome = (outcome: CommandOutcome | undefined, session: Pick<CockpitSession, "sessionEpoch">): boolean =>
+    outcome?.status === "rejected" && outcome.sessionEpoch !== session.sessionEpoch
+
+const isStaleCommandOutcomeForSessions = (
+    outcome: CommandOutcome,
+    sessions: readonly Pick<CockpitSession, "sessionEpoch" | "sessionId">[],
+): boolean => {
+    const activeSession = sessions.find((session) => session.sessionId === outcome.sessionId)
+    return activeSession !== undefined && isStaleCommandOutcome(outcome, activeSession)
+}
 
 const formatCommandKind = (kind: SessionCommand["kind"]): string =>
     kind
@@ -785,7 +793,7 @@ export const getOperatorAttentionSummary = (
         ...fixture.commandOutcomes
             .filter((outcome) => outcome.status === "rejected")
             .map((outcome): OperatorAttentionItem => {
-                const stale = outcome.reason?.toLowerCase().includes("stale") ?? false
+                const stale = isStaleCommandOutcomeForSessions(outcome, fixture.sessions)
                 return {
                     id: `command:${outcome.commandId}`,
                     kind: stale ? "stale-command" : "rejected-command",

--- a/packages/server/src/cli.test.ts
+++ b/packages/server/src/cli.test.ts
@@ -52,6 +52,9 @@ describe("cockpit HTTP server CLI", () => {
         expect(parseCockpitServerArgs([], { CODE_EVERYWHERE_AUTH_TOKEN: "env-secret" })).toMatchObject({
             authToken: "env-secret",
         })
+        expect(parseCockpitServerArgs(["--auth-token", "-leading-hyphen-secret"], {})).toMatchObject({
+            authToken: "-leading-hyphen-secret",
+        })
         expect(parseCockpitServerArgs(["--memory"], {})).toMatchObject({ dataFile: null })
         expect(parseCockpitServerArgs(["--", "--help"], {})).toMatchObject({ help: true })
         expect(parseCockpitServerArgs(["--help"], { CODE_EVERYWHERE_PORT: "nope" })).toMatchObject({ help: true })

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -106,7 +106,7 @@ export const parseCockpitServerArgs = (args: readonly string[], variables: NodeJ
         }
 
         if (arg === "--auth-token") {
-            authToken = readOptionValue(args, index, "--auth-token")
+            authToken = readOptionValue(args, index, "--auth-token", { allowLeadingHyphen: true })
             index += 1
             continue
         }
@@ -213,12 +213,16 @@ const isLoopbackHost = (host: string): boolean => {
     return normalized === "localhost" || normalized === "::1" || normalized === "[::1]" || normalized.startsWith("127.")
 }
 
-const readOptionValue = (args: readonly string[], index: number, option: string): string =>
-    requireNonEmptyValue(args[index + 1], option)
+const readOptionValue = (
+    args: readonly string[],
+    index: number,
+    option: string,
+    options: { allowLeadingHyphen?: boolean } = {},
+): string => requireNonEmptyValue(args[index + 1], option, options)
 
-const requireNonEmptyValue = (value: string | undefined, option: string): string => {
+const requireNonEmptyValue = (value: string | undefined, option: string, options: { allowLeadingHyphen?: boolean } = {}): string => {
     const normalized = normalizeHost(value)
-    if (normalized === undefined || normalized.startsWith("-")) {
+    if (normalized === undefined || (!options.allowLeadingHyphen && normalized.startsWith("-"))) {
         throw new CockpitServerCliError(`${option} requires a value`)
     }
 


### PR DESCRIPTION
## Summary
- Allow broker CLI auth-token values that begin with a hyphen when passed as the next argument
- Classify stale command outcomes by rejected outcome epoch vs active session epoch instead of reason text
- Add focused regression coverage for both behaviors

## Validation
- pnpm --filter @code-everywhere/server test -- cli.test.ts
- pnpm --filter @code-everywhere/web test -- cockpitData.test.ts
- pnpm lint:dry-run
- pnpm validate