### PR TITLE
Document local trust persistence shape

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,6 +66,12 @@ projection events. The local broker persists its event log and command records
 to a repo-ignored JSON file by default. It does not yet provide streaming,
 authentication, direct runtime command execution, or notification delivery.
 
+Local trust should use a separate broker-owned registry beside broker state,
+such as `.code-everywhere/trust.json`, for non-secret trusted host, device, and
+operator records. Broker auth tokens remain route authorization only. Apple
+clients can keep device-held secrets in Keychain later, while the local broker
+continues to own the trusted-record list for the local deployment mode.
+
 ### Clients
 
 Expected client surfaces:

--- a/docs/decisions/0002-local-trust-persistence.md
+++ b/docs/decisions/0002-local-trust-persistence.md
@@ -1,0 +1,54 @@
+# 0002: Local Trust Persistence
+
+## Status
+
+Accepted
+
+## Context
+
+Code Everywhere now has a local broker authorization boundary, but route
+authorization is not product identity. The product still needs a durable local
+model for trusted hosts, operator devices, and automatic session appearance
+before Apple clients, LAN mode, or a hosted relay.
+
+The first trust persistence choice should keep local development simple without
+making token strings carry host, device, and operator meaning.
+
+## Decision
+
+The first production checkpoint should use a broker-mediated, file-backed local
+trust registry.
+
+- The local broker is the authority for local trusted host and device records.
+- The registry should live beside broker state under `.code-everywhere/`, using
+  a separate file such as `.code-everywhere/trust.json` instead of embedding
+  trust records in the event-log persistence file.
+- The registry should store non-secret identity and trust metadata: schema
+  version, local operator id, trusted host ids, trusted device ids, labels,
+  creation time, last-seen time, and revocation state.
+- Session trust should be derived from trusted host identity plus current
+  `sessionId` and `sessionEpoch`; the registry should not create per-session
+  pairing records as the default path.
+- Broker auth tokens remain HTTP route authorization. They should not become the
+  durable host id, operator id, device id, or trust record.
+- Native clients should store device secrets or private credentials in platform
+  storage, such as Keychain on Apple platforms. Those secrets may prove device
+  identity to the broker later, but the broker-owned registry remains the local
+  list of trusted records.
+- Loopback-only development may continue without a trust registry until a host,
+  device, or non-loopback mode needs durable trust. When the registry is present,
+  sessions from trusted hosts should appear automatically.
+
+## Consequences
+
+- Code Everywhere can add stable `hostId`, `operatorId`, and `deviceId` fields
+  without binding them to a shared HTTP token.
+- The local broker has a clear migration path from JSON development state to
+  SQLite or a service-backed store later: trust records are already separated
+  from event replay state.
+- Apple clients can use Keychain for device-held secrets without forcing the
+  Node broker to own platform credential storage in the first checkpoint.
+- Revocation becomes a broker state change instead of a session-by-session
+  pairing cleanup.
+- The next implementation slice should add the smallest typed trust store and
+  config surface before adding host/device protocol fields.

--- a/docs/every-code-integration.md
+++ b/docs/every-code-integration.md
@@ -61,14 +61,20 @@ appear without per-session pairing. Pairing every transient session would fight
 the Every Code workflow and should remain a diagnostic or recovery path, not the
 default interaction model.
 
+The first local trust persistence checkpoint should be broker-mediated and
+file-backed: keep trusted host/device/operator records in a separate local trust
+registry such as `.code-everywhere/trust.json`, while leaving broker auth tokens
+as route authorization only. The trust registry should store non-secret ids,
+labels, timestamps, and revocation state. Native clients can keep device secrets
+in OS storage such as Keychain later, but the broker-owned registry remains the
+local source of trusted records.
+
 Before LAN, hosted relay, or Apple notification work, the missing durable fields
-to evaluate are:
+to add are:
 
 - a stable host identifier separate from human-readable `hostLabel`
 - an operator/account identifier for clients that can enqueue commands
 - a device identifier for native clients and notification routing
-- a storage shape for trusted hosts/devices that is not just the broker auth
-  token
 
 ## What Not To Port
 


### PR DESCRIPTION
## Summary
- Add ADR 0002 for the first local trust persistence checkpoint
- Record broker-mediated, file-backed trust registry as the initial host/device/operator trust shape
- Clarify that broker auth tokens remain route authorization and native device secrets can live in Keychain later

## Validation
- pnpm exec prettier --check docs/decisions/0002-local-trust-persistence.md docs/every-code-integration.md docs/architecture.md
- pnpm lint:dry-run
- pnpm validate

Overlay behavior was not touched.