### PR TITLE
Add local trust registry store

### DIFF
--- a/docs/every-code-integration.md
+++ b/docs/every-code-integration.md
@@ -110,6 +110,11 @@ Every Code adapter that consumes them:
 - the broker persists local state to `.code-everywhere/cockpit-broker.json` by
   default; pass `--memory` for an ephemeral run or `--data-file <path>` to use a
   different file
+- the broker has a separate local trust registry at `.code-everywhere/trust.json`
+  by default; pass `--trust-file <path>` or set `CODE_EVERYWHERE_TRUST_FILE` to
+  use a different registry file
+- `--memory` disables both broker state and trust registry file persistence for
+  the run
 - loopback-only broker usage remains tokenless by default for local development
 - when `--auth-token <token>` or `CODE_EVERYWHERE_AUTH_TOKEN` is set, all broker
   routes require `Authorization: Bearer <token>` or `X-Code-Everywhere-Token`

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -29,6 +29,14 @@
                 "default": "./dist/http-client.js"
             },
             "default": "./src/http-client.ts"
+        },
+        "./trust": {
+            "types": "./src/trust.ts",
+            "node": {
+                "development": "./src/trust.ts",
+                "default": "./dist/trust.js"
+            },
+            "default": "./src/trust.ts"
         }
     },
     "scripts": {

--- a/packages/server/src/cli.test.ts
+++ b/packages/server/src/cli.test.ts
@@ -29,16 +29,28 @@ describe("cockpit HTTP server CLI", () => {
             host: "127.0.0.1",
             port: 4789,
             dataFile: ".code-everywhere/cockpit-broker.json",
+            trustFile: ".code-everywhere/trust.json",
             authToken: null,
             help: false,
         })
         expect(
             parseCockpitServerArgs(
-                ["--host", "0.0.0.0", "--port=4900", "--data-file", "/tmp/cockpit.json", "--auth-token", "arg-secret"],
+                [
+                    "--host",
+                    "0.0.0.0",
+                    "--port=4900",
+                    "--data-file",
+                    "/tmp/cockpit.json",
+                    "--trust-file",
+                    "/tmp/trust.json",
+                    "--auth-token",
+                    "arg-secret",
+                ],
                 {
                     CODE_EVERYWHERE_HOST: "127.0.0.1",
                     CODE_EVERYWHERE_PORT: "nope",
                     CODE_EVERYWHERE_DATA_FILE: "/tmp/env-cockpit.json",
+                    CODE_EVERYWHERE_TRUST_FILE: "/tmp/env-trust.json",
                     CODE_EVERYWHERE_AUTH_TOKEN: "env-secret",
                 },
             ),
@@ -46,8 +58,12 @@ describe("cockpit HTTP server CLI", () => {
             host: "0.0.0.0",
             port: 4900,
             dataFile: "/tmp/cockpit.json",
+            trustFile: "/tmp/trust.json",
             authToken: "arg-secret",
             help: false,
+        })
+        expect(parseCockpitServerArgs([], { CODE_EVERYWHERE_TRUST_FILE: "/tmp/env-trust.json" })).toMatchObject({
+            trustFile: "/tmp/env-trust.json",
         })
         expect(parseCockpitServerArgs([], { CODE_EVERYWHERE_AUTH_TOKEN: "env-secret" })).toMatchObject({
             authToken: "env-secret",
@@ -55,7 +71,7 @@ describe("cockpit HTTP server CLI", () => {
         expect(parseCockpitServerArgs(["--auth-token", "-leading-hyphen-secret"], {})).toMatchObject({
             authToken: "-leading-hyphen-secret",
         })
-        expect(parseCockpitServerArgs(["--memory"], {})).toMatchObject({ dataFile: null })
+        expect(parseCockpitServerArgs(["--memory"], {})).toMatchObject({ dataFile: null, trustFile: null })
         expect(parseCockpitServerArgs(["--", "--help"], {})).toMatchObject({ help: true })
         expect(parseCockpitServerArgs(["--help"], { CODE_EVERYWHERE_PORT: "nope" })).toMatchObject({ help: true })
         expect(() => parseCockpitServerArgs([], { CODE_EVERYWHERE_PORT: "nope" })).toThrow("CODE_EVERYWHERE_PORT must")
@@ -65,6 +81,7 @@ describe("cockpit HTTP server CLI", () => {
         expect(() => parseCockpitServerArgs(["--port", "nope"], {})).toThrow(CockpitServerCliError)
         expect(() => parseCockpitServerArgs(["--host"], {})).toThrow("--host requires a value")
         expect(() => parseCockpitServerArgs(["--data-file"], {})).toThrow("--data-file requires a value")
+        expect(() => parseCockpitServerArgs(["--trust-file"], {})).toThrow("--trust-file requires a value")
         expect(() => parseCockpitServerArgs(["--auth-token"], {})).toThrow("--auth-token requires a value")
         expect(() => parseCockpitServerArgs(["--host", "--port", "4900"], {})).toThrow("--host requires a value")
         expect(() => parseCockpitServerArgs(["--port", "--host", "127.0.0.1"], {})).toThrow("--port requires a value")

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -4,11 +4,13 @@ import { pathToFileURL } from "node:url"
 
 import { createCockpitHttpServer } from "./http.js"
 import { createPersistentCockpitStores } from "./persistence.js"
+import { createLocalTrustRegistryStore, createPersistentLocalTrustRegistryStore, type LocalTrustRegistryStore } from "./trust.js"
 
 export type CockpitServerCliOptions = {
     host: string
     port: number
     dataFile: string | null
+    trustFile: string | null
     authToken: string | null
     help: boolean
 }
@@ -16,25 +18,28 @@ export type CockpitServerCliOptions = {
 export type RunningCockpitServer = {
     server: Server
     url: string
+    trustStore: LocalTrustRegistryStore
 }
 
 const defaultHost = "127.0.0.1"
 const defaultPort = 4789
 const defaultDataFile = ".code-everywhere/cockpit-broker.json"
+const defaultTrustFile = ".code-everywhere/trust.json"
 
 export class CockpitServerCliError extends Error {}
 
 export const formatCockpitServerHelp = (): string => `Code Everywhere cockpit HTTP server
 
 Usage:
-  pnpm cockpit:server [--host 127.0.0.1] [--port 4789] [--data-file .code-everywhere/cockpit-broker.json] [--auth-token <token>]
+  pnpm cockpit:server [--host 127.0.0.1] [--port 4789] [--data-file .code-everywhere/cockpit-broker.json] [--trust-file .code-everywhere/trust.json] [--auth-token <token>]
 
 Options:
   --host <host>            Bind address. Defaults to CODE_EVERYWHERE_HOST or ${defaultHost}.
   --port <port>            Bind port. Defaults to CODE_EVERYWHERE_PORT or ${String(defaultPort)}.
   --data-file <path>       Persistence file. Defaults to CODE_EVERYWHERE_DATA_FILE or ${defaultDataFile}.
+  --trust-file <path>      Local trust registry. Defaults to CODE_EVERYWHERE_TRUST_FILE or ${defaultTrustFile}.
   --auth-token <token>      Require token auth. Defaults to CODE_EVERYWHERE_AUTH_TOKEN.
-  --memory                 Disable file persistence for this run.
+  --memory                 Disable event and trust file persistence for this run.
   -h, --help               Show this help.
 `
 
@@ -44,6 +49,7 @@ export const parseCockpitServerArgs = (args: readonly string[], variables: NodeJ
             host: defaultHost,
             port: defaultPort,
             dataFile: defaultDataFile,
+            trustFile: defaultTrustFile,
             authToken: null,
             help: true,
         }
@@ -52,6 +58,7 @@ export const parseCockpitServerArgs = (args: readonly string[], variables: NodeJ
     let host = normalizeHost(variables.CODE_EVERYWHERE_HOST) ?? defaultHost
     let port: number | undefined
     let dataFile: string | null = normalizeValue(variables.CODE_EVERYWHERE_DATA_FILE) ?? defaultDataFile
+    let trustFile: string | null = normalizeValue(variables.CODE_EVERYWHERE_TRUST_FILE) ?? defaultTrustFile
     let authToken: string | null = normalizeValue(variables.CODE_EVERYWHERE_AUTH_TOKEN) ?? null
     let help = false
 
@@ -102,6 +109,18 @@ export const parseCockpitServerArgs = (args: readonly string[], variables: NodeJ
 
         if (arg === "--memory") {
             dataFile = null
+            trustFile = null
+            continue
+        }
+
+        if (arg === "--trust-file") {
+            trustFile = readOptionValue(args, index, "--trust-file")
+            index += 1
+            continue
+        }
+
+        if (arg?.startsWith("--trust-file=")) {
+            trustFile = requireNonEmptyValue(arg.slice("--trust-file=".length), "--trust-file")
             continue
         }
 
@@ -123,6 +142,7 @@ export const parseCockpitServerArgs = (args: readonly string[], variables: NodeJ
         host,
         port: port ?? parsePort(variables.CODE_EVERYWHERE_PORT, "CODE_EVERYWHERE_PORT") ?? defaultPort,
         dataFile,
+        trustFile,
         authToken,
         help,
     }
@@ -137,7 +157,11 @@ export const cockpitServerUrl = (host: string, port: number): string => {
 }
 
 export const startCockpitHttpServer = async (
-    options: Pick<CockpitServerCliOptions, "host" | "port"> & { authToken?: string | null; dataFile?: string | null },
+    options: Pick<CockpitServerCliOptions, "host" | "port"> & {
+        authToken?: string | null
+        dataFile?: string | null
+        trustFile?: string | null
+    },
 ): Promise<RunningCockpitServer> => {
     const authToken = normalizeValue(options.authToken ?? undefined) ?? null
     if (!isLoopbackHost(options.host) && authToken === null) {
@@ -146,6 +170,10 @@ export const startCockpitHttpServer = async (
 
     const stores =
         options.dataFile === undefined || options.dataFile === null ? undefined : createPersistentCockpitStores(options.dataFile)
+    const trustStore =
+        options.trustFile === undefined || options.trustFile === null
+            ? createLocalTrustRegistryStore()
+            : createPersistentLocalTrustRegistryStore(options.trustFile)
     const server = createCockpitHttpServer({ ...(stores ?? {}), authToken })
     await new Promise<void>((resolve, reject) => {
         const onError = (error: Error) => {
@@ -168,6 +196,7 @@ export const startCockpitHttpServer = async (
     return {
         server,
         url: cockpitServerUrl(options.host, port),
+        trustStore,
     }
 }
 
@@ -187,6 +216,9 @@ export const runCockpitServerCli = async (
         stdout.write(`Code Everywhere cockpit HTTP server listening at ${running.url}\n`)
         if (options.dataFile !== null) {
             stdout.write(`Persisting broker state to ${options.dataFile}\n`)
+        }
+        if (options.trustFile !== null) {
+            stdout.write(`Persisting local trust registry to ${options.trustFile}\n`)
         }
         if (options.authToken !== null) {
             stdout.write("Broker auth token enabled.\n")

--- a/packages/server/src/trust.test.ts
+++ b/packages/server/src/trust.test.ts
@@ -1,0 +1,124 @@
+import { randomUUID } from "node:crypto"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+
+import { describe, expect, it } from "vitest"
+
+import {
+    LocalTrustRegistryError,
+    createLocalTrustRegistryStore,
+    createPersistentLocalTrustRegistryStore,
+    readLocalTrustRegistryFile,
+} from "@code-everywhere/server/trust"
+import type { LocalDeviceTrustRecord, LocalHostTrustRecord, LocalOperatorTrustRecord } from "@code-everywhere/server/trust"
+
+const createdAt = "2026-04-29T18:00:00.000Z"
+
+const operator: LocalOperatorTrustRecord = {
+    operatorId: "operator-local",
+    label: "Local Operator",
+    createdAt,
+    lastSeenAt: null,
+    status: "trusted",
+}
+
+const host: LocalHostTrustRecord = {
+    hostId: "host-workhorse",
+    label: "Workhorse Mac",
+    createdAt,
+    lastSeenAt: "2026-04-29T18:01:00.000Z",
+    status: "trusted",
+}
+
+const device: LocalDeviceTrustRecord = {
+    deviceId: "device-phone",
+    label: "Callisto iPhone",
+    createdAt,
+    lastSeenAt: "2026-04-29T18:02:00.000Z",
+    status: "trusted",
+}
+
+describe("local trust registry", () => {
+    it("uses an empty registry when the file is missing", async () => {
+        const directory = await mkdtemp(join(tmpdir(), "code-everywhere-trust-"))
+        const filePath = join(directory, "trust.json")
+
+        try {
+            expect(readLocalTrustRegistryFile(filePath)).toEqual({
+                version: 1,
+                operator: null,
+                hosts: [],
+                devices: [],
+            })
+        } finally {
+            await rm(directory, { recursive: true, force: true })
+        }
+    })
+
+    it("persists trusted operator, host, and device records separately from auth tokens", async () => {
+        const directory = await mkdtemp(join(tmpdir(), "code-everywhere-trust-"))
+        const filePath = join(directory, "trust.json")
+
+        try {
+            const store = createPersistentLocalTrustRegistryStore(filePath)
+            store.setOperator(operator)
+            store.upsertHost(host)
+            store.upsertDevice(device)
+
+            const reloaded = createPersistentLocalTrustRegistryStore(filePath).getSnapshot()
+            const rawFile = JSON.parse(await readFile(filePath, "utf8")) as Record<string, unknown>
+
+            expect(reloaded).toEqual({
+                version: 1,
+                operator,
+                hosts: [host],
+                devices: [device],
+            })
+            expect(JSON.stringify(rawFile)).not.toContain("authToken")
+            expect(JSON.stringify(rawFile)).not.toContain("CODE_EVERYWHERE_AUTH_TOKEN")
+        } finally {
+            await rm(directory, { recursive: true, force: true })
+        }
+    })
+
+    it("revokes host and device records without deleting them", () => {
+        const store = createLocalTrustRegistryStore()
+        store.upsertHost(host)
+        store.upsertDevice(device)
+
+        const revokedAt = "2026-04-29T18:03:00.000Z"
+        store.revokeHost(host.hostId, revokedAt)
+        store.revokeDevice(device.deviceId, revokedAt)
+
+        expect(store.getSnapshot().hosts).toEqual([{ ...host, lastSeenAt: revokedAt, status: "revoked" }])
+        expect(store.getSnapshot().devices).toEqual([{ ...device, lastSeenAt: revokedAt, status: "revoked" }])
+    })
+
+    it("rejects invalid JSON and invalid registry shapes", async () => {
+        const directory = await mkdtemp(join(tmpdir(), "code-everywhere-trust-"))
+        const filePath = join(directory, "trust.json")
+
+        try {
+            await writeFile(filePath, "not json")
+            expect(() => readLocalTrustRegistryFile(filePath)).toThrow(LocalTrustRegistryError)
+            expect(() => readLocalTrustRegistryFile(filePath)).toThrow("Unable to read local trust registry")
+
+            await writeFile(filePath, JSON.stringify({ version: 1, hosts: [], devices: [] }))
+            expect(() => readLocalTrustRegistryFile(filePath)).toThrow("did not match the expected shape")
+        } finally {
+            await rm(directory, { recursive: true, force: true })
+        }
+    })
+
+    it("rolls back persistent mutations when writes fail", () => {
+        const store = createPersistentLocalTrustRegistryStore(`/tmp/code-everywhere-unused-trust-${randomUUID()}.json`, {
+            writeSnapshot: () => {
+                throw new Error("disk full")
+            },
+        })
+
+        expect(() => store.upsertHost(host)).toThrow("disk full")
+        expect(store.getSnapshot().hosts).toEqual([])
+    })
+})

--- a/packages/server/src/trust.ts
+++ b/packages/server/src/trust.ts
@@ -1,0 +1,226 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs"
+import { dirname } from "node:path"
+
+export type LocalTrustRecordStatus = "trusted" | "revoked"
+
+export type LocalOperatorTrustRecord = {
+    operatorId: string
+    label: string
+    createdAt: string
+    lastSeenAt: string | null
+    status: LocalTrustRecordStatus
+}
+
+export type LocalHostTrustRecord = {
+    hostId: string
+    label: string
+    createdAt: string
+    lastSeenAt: string | null
+    status: LocalTrustRecordStatus
+}
+
+export type LocalDeviceTrustRecord = {
+    deviceId: string
+    label: string
+    createdAt: string
+    lastSeenAt: string | null
+    status: LocalTrustRecordStatus
+}
+
+export type LocalTrustRegistrySnapshot = {
+    version: 1
+    operator: LocalOperatorTrustRecord | null
+    hosts: LocalHostTrustRecord[]
+    devices: LocalDeviceTrustRecord[]
+}
+
+export type LocalTrustRegistryStore = {
+    getSnapshot: () => LocalTrustRegistrySnapshot
+    replace: (snapshot?: LocalTrustRegistrySnapshot) => LocalTrustRegistrySnapshot
+    setOperator: (operator: LocalOperatorTrustRecord | null) => LocalTrustRegistrySnapshot
+    upsertHost: (host: LocalHostTrustRecord) => LocalTrustRegistrySnapshot
+    upsertDevice: (device: LocalDeviceTrustRecord) => LocalTrustRegistrySnapshot
+    revokeHost: (hostId: string, revokedAt: string) => LocalTrustRegistrySnapshot
+    revokeDevice: (deviceId: string, revokedAt: string) => LocalTrustRegistrySnapshot
+}
+
+export type LocalTrustRegistryStoreOptions = {
+    writeSnapshot?: (filePath: string, snapshot: LocalTrustRegistrySnapshot) => void
+}
+
+export class LocalTrustRegistryError extends Error {}
+
+export const createEmptyLocalTrustRegistrySnapshot = (): LocalTrustRegistrySnapshot => ({
+    version: 1,
+    operator: null,
+    hosts: [],
+    devices: [],
+})
+
+export const createLocalTrustRegistryStore = (
+    initialSnapshot: LocalTrustRegistrySnapshot = createEmptyLocalTrustRegistrySnapshot(),
+): LocalTrustRegistryStore => {
+    let snapshot = cloneLocalTrustRegistrySnapshot(initialSnapshot)
+
+    const update = (mutate: (current: LocalTrustRegistrySnapshot) => LocalTrustRegistrySnapshot): LocalTrustRegistrySnapshot => {
+        snapshot = cloneLocalTrustRegistrySnapshot(mutate(cloneLocalTrustRegistrySnapshot(snapshot)))
+        return cloneLocalTrustRegistrySnapshot(snapshot)
+    }
+
+    return {
+        getSnapshot: () => cloneLocalTrustRegistrySnapshot(snapshot),
+        replace: (nextSnapshot = createEmptyLocalTrustRegistrySnapshot()) => update(() => nextSnapshot),
+        setOperator: (operator) =>
+            update((current) => ({
+                ...current,
+                operator: operator === null ? null : { ...operator },
+            })),
+        upsertHost: (host) =>
+            update((current) => ({
+                ...current,
+                hosts: upsertById(current.hosts, host, "hostId"),
+            })),
+        upsertDevice: (device) =>
+            update((current) => ({
+                ...current,
+                devices: upsertById(current.devices, device, "deviceId"),
+            })),
+        revokeHost: (hostId, revokedAt) =>
+            update((current) => ({
+                ...current,
+                hosts: current.hosts.map((host) =>
+                    host.hostId === hostId ? { ...host, lastSeenAt: revokedAt, status: "revoked" } : host,
+                ),
+            })),
+        revokeDevice: (deviceId, revokedAt) =>
+            update((current) => ({
+                ...current,
+                devices: current.devices.map((device) =>
+                    device.deviceId === deviceId ? { ...device, lastSeenAt: revokedAt, status: "revoked" } : device,
+                ),
+            })),
+    }
+}
+
+export const createPersistentLocalTrustRegistryStore = (
+    filePath: string,
+    options: LocalTrustRegistryStoreOptions = {},
+): LocalTrustRegistryStore => {
+    const writeSnapshot = options.writeSnapshot ?? writeLocalTrustRegistryFile
+    const store = createLocalTrustRegistryStore(readLocalTrustRegistryFile(filePath))
+
+    const persistOrRollback = (mutate: () => LocalTrustRegistrySnapshot): LocalTrustRegistrySnapshot => {
+        const previousSnapshot = store.getSnapshot()
+
+        try {
+            const snapshot = mutate()
+            writeSnapshot(filePath, snapshot)
+            return snapshot
+        } catch (error) {
+            store.replace(previousSnapshot)
+            throw error
+        }
+    }
+
+    return {
+        getSnapshot: store.getSnapshot,
+        replace: (snapshot) => persistOrRollback(() => store.replace(snapshot)),
+        setOperator: (operator) => persistOrRollback(() => store.setOperator(operator)),
+        upsertHost: (host) => persistOrRollback(() => store.upsertHost(host)),
+        upsertDevice: (device) => persistOrRollback(() => store.upsertDevice(device)),
+        revokeHost: (hostId, revokedAt) => persistOrRollback(() => store.revokeHost(hostId, revokedAt)),
+        revokeDevice: (deviceId, revokedAt) => persistOrRollback(() => store.revokeDevice(deviceId, revokedAt)),
+    }
+}
+
+export const readLocalTrustRegistryFile = (filePath: string): LocalTrustRegistrySnapshot => {
+    if (!existsSync(filePath)) {
+        return createEmptyLocalTrustRegistrySnapshot()
+    }
+
+    let parsed: unknown
+    try {
+        parsed = JSON.parse(readFileSync(filePath, "utf8")) as unknown
+    } catch (error) {
+        throw new LocalTrustRegistryError(
+            `Unable to read local trust registry ${filePath}: ${error instanceof Error ? error.message : "invalid JSON"}`,
+        )
+    }
+
+    if (!isLocalTrustRegistrySnapshot(parsed)) {
+        throw new LocalTrustRegistryError(`Local trust registry ${filePath} did not match the expected shape`)
+    }
+
+    return cloneLocalTrustRegistrySnapshot(parsed)
+}
+
+export const writeLocalTrustRegistryFile = (filePath: string, snapshot: LocalTrustRegistrySnapshot): void => {
+    mkdirSync(dirname(filePath), { recursive: true })
+    const tempPath = `${filePath}.${String(process.pid)}.tmp`
+    writeFileSync(tempPath, `${JSON.stringify(snapshot, null, 2)}\n`)
+    renameSync(tempPath, filePath)
+}
+
+const cloneLocalTrustRegistrySnapshot = (snapshot: LocalTrustRegistrySnapshot): LocalTrustRegistrySnapshot => ({
+    version: 1,
+    operator: snapshot.operator === null ? null : { ...snapshot.operator },
+    hosts: snapshot.hosts.map((host) => ({ ...host })),
+    devices: snapshot.devices.map((device) => ({ ...device })),
+})
+
+const upsertById = <RecordType extends Record<IdKey, string>, IdKey extends keyof RecordType>(
+    records: RecordType[],
+    record: RecordType,
+    idKey: IdKey,
+): RecordType[] => {
+    const existingIndex = records.findIndex((candidate) => candidate[idKey] === record[idKey])
+    const nextRecord = { ...record }
+
+    if (existingIndex === -1) {
+        return [...records, nextRecord]
+    }
+
+    return records.map((candidate, index) => (index === existingIndex ? nextRecord : candidate))
+}
+
+const isLocalTrustRegistrySnapshot = (value: unknown): value is LocalTrustRegistrySnapshot =>
+    isRecord(value) &&
+    value.version === 1 &&
+    (value.operator === null || isOperatorTrustRecord(value.operator)) &&
+    Array.isArray(value.hosts) &&
+    value.hosts.every(isHostTrustRecord) &&
+    Array.isArray(value.devices) &&
+    value.devices.every(isDeviceTrustRecord)
+
+const isOperatorTrustRecord = (value: unknown): value is LocalOperatorTrustRecord =>
+    isRecord(value) &&
+    isString(value.operatorId) &&
+    isString(value.label) &&
+    isString(value.createdAt) &&
+    isNullableString(value.lastSeenAt) &&
+    isTrustRecordStatus(value.status)
+
+const isHostTrustRecord = (value: unknown): value is LocalHostTrustRecord =>
+    isRecord(value) &&
+    isString(value.hostId) &&
+    isString(value.label) &&
+    isString(value.createdAt) &&
+    isNullableString(value.lastSeenAt) &&
+    isTrustRecordStatus(value.status)
+
+const isDeviceTrustRecord = (value: unknown): value is LocalDeviceTrustRecord =>
+    isRecord(value) &&
+    isString(value.deviceId) &&
+    isString(value.label) &&
+    isString(value.createdAt) &&
+    isNullableString(value.lastSeenAt) &&
+    isTrustRecordStatus(value.status)
+
+const isTrustRecordStatus = (value: unknown): value is LocalTrustRecordStatus => value === "trusted" || value === "revoked"
+
+const isNullableString = (value: unknown): value is string | null => value === null || isString(value)
+
+const isString = (value: unknown): value is string => typeof value === "string"
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === "object" && value !== null && !Array.isArray(value)


### PR DESCRIPTION
## Summary
- Add typed local trust registry records for non-secret operator, host, and device trust metadata
- Add in-memory and file-backed trust registry helpers with shape validation, atomic writes, and rollback on write failure
- Add server CLI trust registry config: --trust-file, CODE_EVERYWHERE_TRUST_FILE, default .code-everywhere/trust.json, and --memory disables trust persistence
- Export the registry via @code-everywhere/server/trust so browser consumers of the server root do not import node:fs
- Document the implemented trust registry config surface

## Validation
- pnpm --filter @code-everywhere/server test -- trust.test.ts cli.test.ts
- pnpm smoke:cockpit:web
- pnpm lint:dry-run && pnpm validate