### PR TITLE
Add optional host identity projection

### DIFF
--- a/apps/web/src/cockpitData.ts
+++ b/apps/web/src/cockpitData.ts
@@ -92,6 +92,7 @@ export type OperatorAttentionSummary = {
 }
 
 const sessionBase = {
+    hostId: "host-callisto-mbp",
     hostLabel: "Callisto MBP",
     cwd: "~/Developer/code-everywhere",
     branch: "main",
@@ -538,6 +539,7 @@ const createCockpitFixtureFromSource = (fixture: SourceCockpitFixture, snapshot:
 const toEveryCodeSession = (session: SourceCockpitSession): EveryCodeSession => ({
     sessionId: session.sessionId,
     sessionEpoch: session.sessionEpoch,
+    ...(session.hostId === undefined ? {} : { hostId: session.hostId }),
     hostLabel: session.hostLabel,
     cwd: session.cwd,
     branch: session.branch,

--- a/apps/web/src/cockpitTransport.test.ts
+++ b/apps/web/src/cockpitTransport.test.ts
@@ -64,6 +64,35 @@ describe("cockpit HTTP transport client", () => {
         })
     })
 
+    it("keeps legacy snapshots without host identity backward-compatible", async () => {
+        const legacySnapshot = {
+            ...cockpitFixtureSnapshot,
+            sessions: cockpitFixtureSnapshot.sessions.map((session) => {
+                const legacySession: Record<string, unknown> = { ...session }
+                delete legacySession.hostId
+                return legacySession
+            }),
+            state: {
+                ...cockpitFixtureSnapshot.state,
+                sessions: Object.fromEntries(
+                    Object.entries(cockpitFixtureSnapshot.state.sessions).map(([sessionId, session]) => {
+                        const legacySession: Record<string, unknown> = { ...session }
+                        delete legacySession.hostId
+                        return [sessionId, legacySession]
+                    }),
+                ),
+            },
+        }
+        const fetchImpl: Parameters<typeof fetchCockpitSnapshot>[1] = () =>
+            Promise.resolve(new Response(JSON.stringify(legacySnapshot), { status: 200 }))
+
+        const snapshot = await fetchCockpitSnapshot("http://127.0.0.1:4789", fetchImpl)
+
+        expect(snapshot.sessions).toHaveLength(cockpitFixtureSnapshot.sessions.length)
+        expect(snapshot.sessions.every((session) => session.hostLabel === "Callisto MBP")).toBe(true)
+        expect(snapshot.sessions.every((session) => session.hostId === undefined)).toBe(true)
+    })
+
     it("keeps empty snapshots as valid live cockpit state", () => {
         const fixture = createCockpitFixtureFromSnapshot({
             eventCount: 0,

--- a/apps/web/src/cockpitTransport.ts
+++ b/apps/web/src/cockpitTransport.ts
@@ -312,6 +312,7 @@ const isProjectedCockpitSession = (value: unknown): value is ProjectedCockpitSes
     isRecord(value) &&
     isString(value.sessionId) &&
     isString(value.sessionEpoch) &&
+    isOptionalString(value.hostId) &&
     isString(value.hostLabel) &&
     isString(value.cwd) &&
     isNullableString(value.branch) &&
@@ -423,6 +424,8 @@ const isArrayOf = <Value>(value: unknown, guard: (entry: unknown) => entry is Va
     Array.isArray(value) && value.every(guard)
 
 const isString = (value: unknown): value is string => typeof value === "string"
+
+const isOptionalString = (value: unknown): value is string | undefined => value === undefined || isString(value)
 
 const isNullableString = (value: unknown): value is string | null => isString(value) || value === null
 

--- a/docs/every-code-integration.md
+++ b/docs/every-code-integration.md
@@ -15,7 +15,7 @@ The Discord bridge currently defines the clearest working version of the Every C
 
 Important existing concepts:
 
-- `SessionHello` identifies a session with `session_id`, `session_epoch`, host label, cwd, branch, and pid.
+- `SessionHello` identifies a session with `session_id`, `session_epoch`, optional stable `host_id`, host label, cwd, branch, and pid.
 - Session epoch protects against stale commands after reconnects.
 - `RemoteCommand` covers reply, continue, pause, end, status, and requested-input responses.
 - Approval requests are explicit and require approve/deny decisions.
@@ -43,8 +43,9 @@ Code Everywhere should use separate identity concepts:
   loopback-only by default, or a configured shared token when protected or bound
   beyond loopback.
 - **Host identity**: the machine or runtime installation that launches trusted
-  Every Code sessions. Current projections expose only `hostLabel`, cwd, branch,
-  pid, and model; there is no durable `hostId` yet.
+  Every Code sessions. Current projections support optional `hostId` alongside
+  `hostLabel`, cwd, branch, pid, and model so legacy publishers can continue
+  without host trust while newer publishers can provide stable host identity.
 - **Session identity**: the runtime session represented by `sessionId` and the
   reconnect/staleness scope represented by `sessionEpoch`. Commands and pending
   work must keep using both values.
@@ -72,7 +73,8 @@ local source of trusted records.
 Before LAN, hosted relay, or Apple notification work, the missing durable fields
 to add are:
 
-- a stable host identifier separate from human-readable `hostLabel`
+- Every Code overlay publication of a stable host identifier separate from
+  human-readable `hostLabel`
 - an operator/account identifier for clients that can enqueue commands
 - a device identifier for native clients and notification routing
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -5,6 +5,7 @@ export type TurnId = string
 export type EveryCodeSession = {
     sessionId: SessionId
     sessionEpoch: SessionEpoch
+    hostId?: string
     hostLabel: string
     cwd: string
     branch: string | null

--- a/packages/contracts/src/projection.test.ts
+++ b/packages/contracts/src/projection.test.ts
@@ -11,6 +11,7 @@ import {
 const baseSession: EveryCodeSession = {
     sessionId: "session-1",
     sessionEpoch: "epoch-1",
+    hostId: "host-workhorse",
     hostLabel: "workhorse-mac",
     cwd: "~/code/code-everywhere",
     branch: "main",
@@ -95,10 +96,22 @@ describe("cockpit projection", () => {
         ])
 
         expect(state.sessions["session-1"]?.status).toBe("idle")
+        expect(state.sessions["session-1"]?.hostId).toBe("host-workhorse")
         expect(state.sessions["session-1"]?.currentTurnId).toBe("turn-1")
         expect(state.sessions["session-1"]?.turnIds).toEqual(["turn-1"])
         expect(state.turns["turn-1"]?.status).toBe("completed")
         expect(state.turns["turn-1"]?.steps).toHaveLength(1)
+    })
+
+    it("keeps legacy session hello events without host identity valid", () => {
+        const legacySession: EveryCodeSession = {
+            ...baseSession,
+        }
+        delete legacySession.hostId
+        const state = projectCockpitEvents([{ kind: "session_hello", session: legacySession }])
+
+        expect(state.sessions["session-1"]?.hostLabel).toBe("workhorse-mac")
+        expect(state.sessions["session-1"]?.hostId).toBeUndefined()
     })
 
     it("keeps replayed turn steps idempotent", () => {

--- a/packages/server/src/http.test.ts
+++ b/packages/server/src/http.test.ts
@@ -16,6 +16,7 @@ import { createCockpitHttpServer } from "./http"
 const baseSession: EveryCodeSession = {
     sessionId: "session-1",
     sessionEpoch: "epoch-1",
+    hostId: "host-workhorse",
     hostLabel: "workhorse-mac",
     cwd: "~/code/code-everywhere",
     branch: "main",
@@ -144,11 +145,29 @@ describe("cockpit HTTP transport", () => {
         expect(approvalResponse.statusCode).toBe(200)
         const body = approvalResponse.body as CockpitIngestionSnapshot
 
+        expect(body.sessions[0]?.hostId).toBe("host-workhorse")
         expect(body).toMatchObject({
             eventCount: 2,
             attentionSessionIds: ["session-1"],
         })
         expect(body.state.pendingApprovals["approval-1"]).toEqual(baseApproval)
+    })
+
+    it("keeps legacy session hello payloads without host identity valid", async () => {
+        const legacySession: EveryCodeSession = { ...baseSession }
+        delete legacySession.hostId
+
+        const response = await sendJson(baseUrl, "POST", "/events", {
+            event: {
+                kind: "session_hello",
+                session: legacySession,
+            },
+        })
+
+        expect(response.statusCode).toBe(200)
+        const body = response.body as CockpitIngestionSnapshot
+        expect(body.sessions[0]?.hostLabel).toBe("workhorse-mac")
+        expect(body.sessions[0]?.hostId).toBeUndefined()
     })
 
     it("ingests command outcome events", async () => {

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -437,6 +437,7 @@ const isEveryCodeSession = (value: unknown): value is EveryCodeSession =>
     isRecord(value) &&
     hasString(value, "sessionId") &&
     hasString(value, "sessionEpoch") &&
+    hasOptionalString(value, "hostId") &&
     hasString(value, "hostLabel") &&
     hasString(value, "cwd") &&
     hasNullableString(value, "branch") &&


### PR DESCRIPTION
## Summary
- Add optional hostId to EveryCodeSession and projected sessions
- Accept optional hostId in server HTTP ingest and web snapshot validation while preserving legacy payloads without host identity
- Add fixture coverage for host identity and compatibility tests for legacy session hello/snapshot payloads
- Document hostId as the stable host identity field and record Every Code overlay publication as the remaining follow-up

## Validation
- pnpm --filter @code-everywhere/contracts test -- projection.test.ts
- pnpm --filter @code-everywhere/server test -- http.test.ts
- pnpm --filter @code-everywhere/web test -- cockpitTransport.test.ts
- pnpm lint:dry-run && pnpm validate && pnpm smoke:cockpit:web

Overlay behavior was not touched; publication remains tracked in the plan.