### PR TITLE
Derive session trust from host registry

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -27,6 +27,8 @@ import {
     Play,
     Send,
     ShieldAlert,
+    ShieldCheck,
+    ShieldQuestion,
     Square,
     TerminalSquare,
     X,
@@ -91,6 +93,29 @@ const statusTone: Record<SessionStatus, string> = {
     "waiting-for-approval": "is-waiting-approval",
     ended: "is-ended",
     error: "is-error",
+}
+
+type SessionTrustStatus = CockpitSession["trust"]["status"]
+
+const trustLabels: Record<SessionTrustStatus, string> = {
+    trusted: "Trusted",
+    unknown: "Unknown host",
+    revoked: "Revoked host",
+    unidentified: "No host id",
+}
+
+const compactTrustLabels: Record<SessionTrustStatus, string> = {
+    trusted: "Trusted",
+    unknown: "Unknown",
+    revoked: "Revoked",
+    unidentified: "No ID",
+}
+
+const trustTone: Record<SessionTrustStatus, string> = {
+    trusted: "is-trusted",
+    unknown: "is-unknown",
+    revoked: "is-revoked",
+    unidentified: "is-unidentified",
 }
 
 const stepTone: Record<TurnStep["state"], string> = {
@@ -307,7 +332,7 @@ const SessionList = ({ sessions, activeSessionId, onSelect }: SessionListProps) 
     <aside className="panel session-list" aria-label="Sessions">
         <div className="panel-heading">
             <div>
-                <p className="eyebrow">Trusted sessions</p>
+                <p className="eyebrow">Sessions</p>
                 <h2>Attention queue</h2>
             </div>
             <span className="count-badge">{sessions.length}</span>
@@ -317,7 +342,7 @@ const SessionList = ({ sessions, activeSessionId, onSelect }: SessionListProps) 
             {sessions.length === 0 ? (
                 <div className="empty-state session-empty">
                     <Check size={16} />
-                    <p>No trusted sessions in this snapshot.</p>
+                    <p>No sessions in this snapshot.</p>
                 </div>
             ) : null}
             {sessions.map((session) => (
@@ -334,7 +359,10 @@ const SessionList = ({ sessions, activeSessionId, onSelect }: SessionListProps) 
                     <span className="session-updated">{formatTime(session.updatedAt)}</span>
                     <ChevronRight className="session-chevron" size={14} aria-hidden="true" />
                     <span className="session-meta">
-                        {session.hostLabel} <span aria-hidden="true">/</span> {session.branch ?? "detached"}
+                        <span className="session-hostline">
+                            {session.hostLabel} <span aria-hidden="true">/</span> {session.branch ?? "detached"}
+                        </span>
+                        <TrustPill trust={session.trust} compact />
                     </span>
                 </button>
             ))}
@@ -511,6 +539,7 @@ const SessionDetail = ({ session, reply, setReply, dispatchCommand }: SessionDet
 
         <div className="metadata-strip" aria-label="Session metadata">
             <MetadataItem icon={MonitorDot} label="Host" value={`${session.hostLabel} / pid ${String(session.pid)}`} />
+            <MetadataItem icon={trustMetadataIcon(session.trust.status)} label="Trust" value={trustMetadataValue(session)} />
             <MetadataItem icon={GitBranch} label="Branch" value={session.branch ?? "detached"} />
             <MetadataItem icon={TerminalSquare} label="Working directory" value={session.cwd} />
             <MetadataItem icon={Info} label="Model" value={session.model} />
@@ -879,6 +908,17 @@ const StatusPill = ({ status, compact = false }: { status: SessionStatus; compac
     )
 }
 
+const TrustPill = ({ trust, compact = false }: { trust: CockpitSession["trust"]; compact?: boolean }) => {
+    const Icon = trustMetadataIcon(trust.status)
+
+    return (
+        <span className={`trust-pill ${trustTone[trust.status]} ${compact ? "is-compact" : ""}`} title={trustMetadataLabel(trust)}>
+            <Icon size={compact ? 11 : 13} aria-hidden="true" />
+            {compact ? compactTrustLabels[trust.status] : trustLabels[trust.status]}
+        </span>
+    )
+}
+
 const StatusSummary = ({ count }: { count: number }) => (
     <div className="status-summary">
         <span>{count}</span>
@@ -901,14 +941,39 @@ const MetadataItem = ({ icon: Icon, label, value }: { icon: IconComponent; label
     </div>
 )
 
+const trustMetadataIcon = (status: SessionTrustStatus): IconComponent => {
+    switch (status) {
+        case "trusted":
+            return ShieldCheck
+        case "revoked":
+            return ShieldAlert
+        case "unknown":
+        case "unidentified":
+            return ShieldQuestion
+    }
+}
+
+const trustMetadataLabel = (trust: CockpitSession["trust"]): string => {
+    if (trust.status === "trusted" || trust.status === "revoked") {
+        return `${trustLabels[trust.status]}: ${trust.trustedHostLabel ?? trust.hostId ?? trust.hostLabel}`
+    }
+
+    return trustLabels[trust.status]
+}
+
+const trustMetadataValue = (session: CockpitSession): string => {
+    const label = trustMetadataLabel(session.trust)
+    return session.trust.hostId === null ? label : `${label} / ${session.trust.hostId}`
+}
+
 const emptySessionDetailCopy = (transport: CockpitTransportStatus): string => {
     switch (transport.mode) {
         case "fixture":
             return "The cockpit is showing fake data because no local broker URL is configured."
         case "connecting":
-            return "The cockpit is connecting to the local broker and has not received trusted Every Code sessions yet."
+            return "The cockpit is connecting to the local broker and has not received Every Code sessions yet."
         case "live":
-            return "The local broker is connected and healthy, but it does not contain trusted Every Code sessions yet."
+            return "The local broker is connected and healthy, but it does not contain Every Code sessions yet."
         case "fallback":
             return transport.error === null
                 ? "The cockpit is showing the last known snapshot because the local broker is unavailable."
@@ -956,7 +1021,7 @@ export const getCockpitStateSurface = (
         return {
             tone: "success",
             title: "No live sessions",
-            detail: "The broker is healthy, but no trusted Every Code sessions have published a snapshot yet.",
+            detail: "The broker is healthy, but no Every Code sessions have published a snapshot yet.",
         }
     }
 

--- a/apps/web/src/cockpitTransport.test.ts
+++ b/apps/web/src/cockpitTransport.test.ts
@@ -70,6 +70,7 @@ describe("cockpit HTTP transport client", () => {
             sessions: cockpitFixtureSnapshot.sessions.map((session) => {
                 const legacySession: Record<string, unknown> = { ...session }
                 delete legacySession.hostId
+                delete legacySession.trust
                 return legacySession
             }),
             state: {
@@ -78,6 +79,7 @@ describe("cockpit HTTP transport client", () => {
                     Object.entries(cockpitFixtureSnapshot.state.sessions).map(([sessionId, session]) => {
                         const legacySession: Record<string, unknown> = { ...session }
                         delete legacySession.hostId
+                        delete legacySession.trust
                         return [sessionId, legacySession]
                     }),
                 ),
@@ -91,6 +93,50 @@ describe("cockpit HTTP transport client", () => {
         expect(snapshot.sessions).toHaveLength(cockpitFixtureSnapshot.sessions.length)
         expect(snapshot.sessions.every((session) => session.hostLabel === "Callisto MBP")).toBe(true)
         expect(snapshot.sessions.every((session) => session.hostId === undefined)).toBe(true)
+        expect(snapshot.sessions.every((session) => session.trust.status === "unidentified")).toBe(true)
+        expect(Object.values(snapshot.state.sessions).every((session) => session.trust.hostId === null)).toBe(true)
+    })
+
+    it("validates trust-aware snapshot sessions", async () => {
+        const trustedSnapshot = {
+            ...cockpitFixtureSnapshot,
+            sessions: cockpitFixtureSnapshot.sessions.map((session) => ({
+                ...session,
+                trust: {
+                    status: "trusted",
+                    hostId: session.hostId,
+                    hostLabel: session.hostLabel,
+                    trustedHostLabel: "Callisto MBP",
+                    lastSeenAt: "2026-04-27T16:04:00.000Z",
+                },
+            })),
+            state: {
+                ...cockpitFixtureSnapshot.state,
+                sessions: Object.fromEntries(
+                    Object.entries(cockpitFixtureSnapshot.state.sessions).map(([sessionId, session]) => [
+                        sessionId,
+                        {
+                            ...session,
+                            trust: {
+                                status: "trusted",
+                                hostId: session.hostId,
+                                hostLabel: session.hostLabel,
+                                trustedHostLabel: "Callisto MBP",
+                                lastSeenAt: "2026-04-27T16:04:00.000Z",
+                            },
+                        },
+                    ]),
+                ),
+            },
+        }
+        const fetchImpl: Parameters<typeof fetchCockpitSnapshot>[1] = () =>
+            Promise.resolve(new Response(JSON.stringify(trustedSnapshot), { status: 200 }))
+
+        const snapshot = await fetchCockpitSnapshot("http://127.0.0.1:4789", fetchImpl)
+
+        expect(snapshot.sessions).toHaveLength(cockpitFixtureSnapshot.sessions.length)
+        expect(snapshot.sessions.every((session) => session.trust.status === "trusted")).toBe(true)
+        expect(snapshot.sessions.every((session) => session.trust.trustedHostLabel === "Callisto MBP")).toBe(true)
     })
 
     it("keeps empty snapshots as valid live cockpit state", () => {

--- a/apps/web/src/cockpitTransport.ts
+++ b/apps/web/src/cockpitTransport.ts
@@ -14,6 +14,7 @@ import type {
     TurnStatus,
     TurnStep,
 } from "@code-everywhere/contracts"
+import { createDefaultSessionTrust } from "@code-everywhere/contracts"
 import type { CockpitCommandRecord, CockpitCommandSnapshot, CockpitIngestionSnapshot } from "@code-everywhere/server"
 
 import { fetchCockpitCommands } from "./cockpitCommands"
@@ -268,22 +269,27 @@ const normalizeCockpitIngestionSnapshot = (value: unknown): CockpitIngestionSnap
     }
 
     const state = normalizeCockpitProjectionState(value.state)
-    if (state === null || !isArrayOf(value.sessions, isProjectedCockpitSession) || !isArrayOf(value.attentionSessionIds, isString)) {
+    const sessions = normalizeProjectedCockpitSessions(value.sessions)
+    if (state === null || sessions === null || !isArrayOf(value.attentionSessionIds, isString)) {
         return null
     }
 
     return {
         eventCount: value.eventCount,
         state,
-        sessions: value.sessions,
+        sessions,
         attentionSessionIds: value.attentionSessionIds,
     }
 }
 
 const normalizeCockpitProjectionState = (value: unknown): CockpitProjectionState | null => {
+    if (!isRecord(value)) {
+        return null
+    }
+
+    const sessions = normalizeProjectedCockpitSessionRecord(value.sessions)
     if (
-        !isRecord(value) ||
-        !isRecordOf(value.sessions, isProjectedCockpitSession) ||
+        sessions === null ||
         !isRecordOf(value.turns, isSessionTurn) ||
         !isRecordOf(value.pendingApprovals, isPendingApproval) ||
         !isRecordOf(value.requestedInputs, isRequestedInput) ||
@@ -298,7 +304,7 @@ const normalizeCockpitProjectionState = (value: unknown): CockpitProjectionState
     }
 
     return {
-        sessions: value.sessions,
+        sessions,
         turns: value.turns,
         pendingApprovals: value.pendingApprovals,
         requestedInputs: value.requestedInputs,
@@ -308,7 +314,51 @@ const normalizeCockpitProjectionState = (value: unknown): CockpitProjectionState
     }
 }
 
-const isProjectedCockpitSession = (value: unknown): value is ProjectedCockpitSession =>
+const normalizeProjectedCockpitSessions = (value: unknown): ProjectedCockpitSession[] | null => {
+    if (!Array.isArray(value)) {
+        return null
+    }
+
+    const sessions = value.map(normalizeProjectedCockpitSession)
+    return sessions.every((session): session is ProjectedCockpitSession => session !== null) ? sessions : null
+}
+
+const normalizeProjectedCockpitSessionRecord = (value: unknown): Record<string, ProjectedCockpitSession> | null => {
+    if (!isRecord(value)) {
+        return null
+    }
+
+    const entries = Object.entries(value).map(
+        ([sessionId, session]) => [sessionId, normalizeProjectedCockpitSession(session)] as const,
+    )
+    if (entries.some(([, session]) => session === null)) {
+        return null
+    }
+
+    return Object.fromEntries(entries) as Record<string, ProjectedCockpitSession>
+}
+
+const normalizeProjectedCockpitSession = (value: unknown): ProjectedCockpitSession | null => {
+    if (!isProjectedCockpitSessionBase(value)) {
+        return null
+    }
+
+    const trust = value.trust ?? createDefaultSessionTrust(value)
+    if (!isSessionTrust(trust)) {
+        return null
+    }
+
+    return {
+        ...value,
+        trust,
+    }
+}
+
+const isProjectedCockpitSessionBase = (
+    value: unknown,
+): value is Omit<ProjectedCockpitSession, "trust"> & {
+    trust?: ProjectedCockpitSession["trust"]
+} =>
     isRecord(value) &&
     isString(value.sessionId) &&
     isString(value.sessionEpoch) &&
@@ -327,6 +377,14 @@ const isProjectedCockpitSession = (value: unknown): value is ProjectedCockpitSes
     isArrayOf(value.pendingApprovalIds, isString) &&
     isArrayOf(value.pendingInputIds, isString) &&
     isArrayOf(value.turnIds, isString)
+
+const isSessionTrust = (value: unknown): value is ProjectedCockpitSession["trust"] =>
+    isRecord(value) &&
+    isSessionTrustStatus(value.status) &&
+    isNullableString(value.hostId) &&
+    isString(value.hostLabel) &&
+    isNullableString(value.trustedHostLabel) &&
+    isNullableString(value.lastSeenAt)
 
 const isSessionTurn = (value: unknown): value is SessionTurn =>
     isRecord(value) &&
@@ -431,6 +489,9 @@ const isNullableString = (value: unknown): value is string | null => isString(va
 
 const isSessionStatus = (value: unknown): value is SessionStatus =>
     isOneOf(value, ["running", "idle", "blocked", "waiting-for-input", "waiting-for-approval", "ended", "error"])
+
+const isSessionTrustStatus = (value: unknown): value is ProjectedCockpitSession["trust"]["status"] =>
+    isOneOf(value, ["trusted", "unknown", "revoked", "unidentified"])
 
 const isTurnStatus = (value: unknown): value is TurnStatus =>
     isOneOf(value, ["running", "completed", "blocked", "waiting-for-input", "waiting-for-approval", "error"])

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -439,6 +439,16 @@ code {
     white-space: nowrap;
 }
 
+.session-hostline {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.session-meta .trust-pill {
+    flex: 0 0 auto;
+}
+
 .session-row > .status-dot {
     grid-area: dot;
 }
@@ -1035,6 +1045,7 @@ legend {
 }
 
 .status-pill,
+.trust-pill,
 .turn-status,
 .count-badge,
 .unread-count {
@@ -1050,12 +1061,14 @@ legend {
     white-space: nowrap;
 }
 
-.status-pill {
+.status-pill,
+.trust-pill {
     border: 1px solid;
     padding: 4px 8px;
 }
 
-.status-pill.is-compact {
+.status-pill.is-compact,
+.trust-pill.is-compact {
     min-width: 0;
     max-width: 92px;
     padding: 3px 7px;
@@ -1065,7 +1078,8 @@ legend {
 }
 
 .status-pill.is-compact svg,
-.status-pill.is-compact .status-dot {
+.status-pill.is-compact .status-dot,
+.trust-pill.is-compact svg {
     flex: 0 0 auto;
 }
 
@@ -1114,6 +1128,25 @@ legend {
     border-color: var(--warning-border);
     background: var(--warning-bg-soft);
     color: var(--warning-text);
+}
+
+.trust-pill.is-trusted {
+    border-color: var(--success-border);
+    background: var(--success-bg-soft);
+    color: var(--success-text);
+}
+
+.trust-pill.is-unknown,
+.trust-pill.is-unidentified {
+    border-color: var(--muted-border);
+    background: var(--muted-bg-soft);
+    color: var(--fg-2);
+}
+
+.trust-pill.is-revoked {
+    border-color: var(--danger-border);
+    background: var(--danger-bg-soft);
+    color: var(--danger-text);
 }
 
 .status-pill.is-running .status-dot,
@@ -1645,7 +1678,8 @@ legend {
         max-width: 122px;
     }
 
-    .status-pill.is-compact {
+    .status-pill.is-compact,
+    .trust-pill.is-compact {
         max-width: 122px;
     }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,7 +70,9 @@ Local trust should use a separate broker-owned registry beside broker state,
 such as `.code-everywhere/trust.json`, for non-secret trusted host, device, and
 operator records. Broker auth tokens remain route authorization only. Apple
 clients can keep device-held secrets in Keychain later, while the local broker
-continues to own the trusted-record list for the local deployment mode.
+continues to own the trusted-record list for the local deployment mode. Broker
+snapshots derive session trust from projected `hostId` and the host registry;
+sessions without a host id remain explicit unverified legacy sessions.
 
 ### Clients
 

--- a/docs/every-code-integration.md
+++ b/docs/every-code-integration.md
@@ -46,6 +46,9 @@ Code Everywhere should use separate identity concepts:
   Every Code sessions. Current projections support optional `hostId` alongside
   `hostLabel`, cwd, branch, pid, and model so legacy publishers can continue
   without host trust while newer publishers can provide stable host identity.
+  Broker snapshots derive each session's trust status from `hostId` and the
+  local trust registry: `trusted`, `unknown`, `revoked`, or `unidentified` when
+  a legacy publisher has no host id.
 - **Session identity**: the runtime session represented by `sessionId` and the
   reconnect/staleness scope represented by `sessionEpoch`. Commands and pending
   work must keep using both values.
@@ -62,19 +65,17 @@ appear without per-session pairing. Pairing every transient session would fight
 the Every Code workflow and should remain a diagnostic or recovery path, not the
 default interaction model.
 
-The first local trust persistence checkpoint should be broker-mediated and
-file-backed: keep trusted host/device/operator records in a separate local trust
-registry such as `.code-everywhere/trust.json`, while leaving broker auth tokens
-as route authorization only. The trust registry should store non-secret ids,
-labels, timestamps, and revocation state. Native clients can keep device secrets
-in OS storage such as Keychain later, but the broker-owned registry remains the
-local source of trusted records.
+The first local trust persistence checkpoint is broker-mediated and file-backed:
+keep trusted host/device/operator records in a separate local trust registry such
+as `.code-everywhere/trust.json`, while leaving broker auth tokens as route
+authorization only. The trust registry stores non-secret ids, labels,
+timestamps, and revocation state. Native clients can keep device secrets in OS
+storage such as Keychain later, but the broker-owned registry remains the local
+source of trusted records.
 
 Before LAN, hosted relay, or Apple notification work, the missing durable fields
 to add are:
 
-- Every Code overlay publication of a stable host identifier separate from
-  human-readable `hostLabel`
 - an operator/account identifier for clients that can enqueue commands
 - a device identifier for native clients and notification routing
 
@@ -131,6 +132,8 @@ Every Code adapter that consumes them:
   from `@code-everywhere/server/http-client`
 - adapter code should publish session events with the typed `postCockpitEvents`
   helper exported from the same module
+- `/snapshot` returns projected sessions with `trust.status`; route auth tokens
+  authorize broker access but never mark a session trusted
 - web clients pass broker auth with `VITE_COCKPIT_AUTH_TOKEN` when the broker is
   started with a token
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -22,6 +22,16 @@ export type SessionStatus = "running" | "idle" | "blocked" | "waiting-for-input"
 
 export type TurnStatus = "running" | "completed" | "blocked" | "waiting-for-input" | "waiting-for-approval" | "error"
 
+export type SessionTrustStatus = "trusted" | "unknown" | "revoked" | "unidentified"
+
+export type SessionTrust = {
+    status: SessionTrustStatus
+    hostId: string | null
+    hostLabel: string
+    trustedHostLabel: string | null
+    lastSeenAt: string | null
+}
+
 export type SessionTurn = {
     id: TurnId
     sessionId: SessionId
@@ -154,6 +164,7 @@ export type RequestedInputOption = {
 }
 
 export type ProjectedCockpitSession = EveryCodeSession & {
+    trust: SessionTrust
     attention: "none" | "approval" | "input" | "blocked" | "error"
     pendingApprovalIds: string[]
     pendingInputIds: string[]
@@ -465,6 +476,7 @@ const projectSessionHello = (state: CockpitProjectionState, session: EveryCodeSe
 
     draft.sessions[session.sessionId] = withAttention({
         ...session,
+        trust: createDefaultSessionTrust(session),
         pendingApprovalIds: epochChanged || existing === undefined ? [] : existing.pendingApprovalIds,
         pendingInputIds: epochChanged || existing === undefined ? [] : existing.pendingInputIds,
         turnIds: epochChanged || existing === undefined ? [] : existing.turnIds,
@@ -472,6 +484,14 @@ const projectSessionHello = (state: CockpitProjectionState, session: EveryCodeSe
 
     return draft
 }
+
+export const createDefaultSessionTrust = (session: Pick<EveryCodeSession, "hostId" | "hostLabel">): SessionTrust => ({
+    status: session.hostId === undefined || session.hostId.trim() === "" ? "unidentified" : "unknown",
+    hostId: session.hostId === undefined || session.hostId.trim() === "" ? null : session.hostId,
+    hostLabel: session.hostLabel,
+    trustedHostLabel: null,
+    lastSeenAt: null,
+})
 
 const withCurrentSession = (
     state: CockpitProjectionState,

--- a/packages/contracts/src/projection.test.ts
+++ b/packages/contracts/src/projection.test.ts
@@ -97,6 +97,13 @@ describe("cockpit projection", () => {
 
         expect(state.sessions["session-1"]?.status).toBe("idle")
         expect(state.sessions["session-1"]?.hostId).toBe("host-workhorse")
+        expect(state.sessions["session-1"]?.trust).toEqual({
+            status: "unknown",
+            hostId: "host-workhorse",
+            hostLabel: "workhorse-mac",
+            trustedHostLabel: null,
+            lastSeenAt: null,
+        })
         expect(state.sessions["session-1"]?.currentTurnId).toBe("turn-1")
         expect(state.sessions["session-1"]?.turnIds).toEqual(["turn-1"])
         expect(state.turns["turn-1"]?.status).toBe("completed")
@@ -112,6 +119,8 @@ describe("cockpit projection", () => {
 
         expect(state.sessions["session-1"]?.hostLabel).toBe("workhorse-mac")
         expect(state.sessions["session-1"]?.hostId).toBeUndefined()
+        expect(state.sessions["session-1"]?.trust.status).toBe("unidentified")
+        expect(state.sessions["session-1"]?.trust.hostId).toBeNull()
     })
 
     it("keeps replayed turn steps idempotent", () => {

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -174,7 +174,7 @@ export const startCockpitHttpServer = async (
         options.trustFile === undefined || options.trustFile === null
             ? createLocalTrustRegistryStore()
             : createPersistentLocalTrustRegistryStore(options.trustFile)
-    const server = createCockpitHttpServer({ ...(stores ?? {}), authToken })
+    const server = createCockpitHttpServer({ ...(stores ?? {}), trustStore, authToken })
     await new Promise<void>((resolve, reject) => {
         const onError = (error: Error) => {
             server.off("listening", onListening)

--- a/packages/server/src/http.test.ts
+++ b/packages/server/src/http.test.ts
@@ -12,6 +12,7 @@ import {
     type CockpitIngestionSnapshot,
 } from "./index"
 import { createCockpitHttpServer } from "./http"
+import { createLocalTrustRegistryStore } from "./trust"
 
 const baseSession: EveryCodeSession = {
     sessionId: "session-1",
@@ -168,6 +169,46 @@ describe("cockpit HTTP transport", () => {
         const body = response.body as CockpitIngestionSnapshot
         expect(body.sessions[0]?.hostLabel).toBe("workhorse-mac")
         expect(body.sessions[0]?.hostId).toBeUndefined()
+        expect(body.sessions[0]?.trust.status).toBe("unidentified")
+    })
+
+    it("returns trust-aware sessions from the configured trust registry", async () => {
+        const trustStore = createLocalTrustRegistryStore()
+        trustStore.upsertHost({
+            hostId: "host-workhorse",
+            label: "Workhorse Mac",
+            createdAt: "2026-04-27T16:00:00.000Z",
+            lastSeenAt: "2026-04-27T16:10:00.000Z",
+            status: "trusted",
+        })
+        const trustedServer = createCockpitHttpServer({ trustStore })
+        let trustedBaseUrl: string
+
+        try {
+            await new Promise<void>((resolve) => {
+                trustedServer.listen(0, "127.0.0.1", resolve)
+            })
+            const address = trustedServer.address() as AddressInfo
+            trustedBaseUrl = `http://127.0.0.1:${String(address.port)}`
+
+            const response = await sendJson(trustedBaseUrl, "POST", "/events", {
+                event: {
+                    kind: "session_hello",
+                    session: baseSession,
+                },
+            })
+
+            expect(response.statusCode).toBe(200)
+            expect((response.body as CockpitIngestionSnapshot).sessions[0]?.trust).toEqual({
+                status: "trusted",
+                hostId: "host-workhorse",
+                hostLabel: "workhorse-mac",
+                trustedHostLabel: "Workhorse Mac",
+                lastSeenAt: "2026-04-27T16:10:00.000Z",
+            })
+        } finally {
+            await new Promise<void>((resolve) => trustedServer.close(() => resolve()))
+        }
     })
 
     it("ingests command outcome events", async () => {

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -25,10 +25,12 @@ import {
     type CockpitEventStore,
     type CockpitIngestionSnapshot,
 } from "./index.js"
+import type { LocalTrustRegistryStore } from "./trust.js"
 
 export type CockpitHttpHandlerOptions = {
     store?: CockpitEventStore
     commandStore?: CockpitCommandStore
+    trustStore?: LocalTrustRegistryStore
     maxBodyBytes?: number
     authToken?: string | null
 }
@@ -73,7 +75,11 @@ const sessionCommandKindValues = [
 const commandOutcomeStatusValues = ["accepted", "rejected"] as const satisfies readonly CommandOutcome["status"][]
 
 export const createCockpitHttpHandler = (options: CockpitHttpHandlerOptions = {}) => {
-    const store = options.store ?? createCockpitEventStore()
+    const store =
+        options.store ??
+        (options.trustStore === undefined
+            ? createCockpitEventStore()
+            : createCockpitEventStore([], { trustStore: options.trustStore }))
     const commandStore = options.commandStore ?? createCockpitCommandStore()
     const maxBodyBytes = options.maxBodyBytes ?? defaultMaxBodyBytes
     const authToken = normalizeAuthToken(options.authToken)

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -9,6 +9,7 @@ import type {
 } from "@code-everywhere/contracts"
 
 import { createCockpitCommandStore, createCockpitEventStore } from "./index"
+import { createLocalTrustRegistryStore } from "./trust"
 
 const baseSession: EveryCodeSession = {
     sessionId: "session-1",
@@ -86,6 +87,49 @@ describe("cockpit event store", () => {
         expect(snapshot.sessions[0]?.status).toBe("waiting-for-approval")
         expect(snapshot.attentionSessionIds).toEqual(["session-1"])
         expect(snapshot.state.pendingApprovals["approval-1"]).toEqual(baseApproval)
+    })
+
+    it("derives session trust from current local host trust records", () => {
+        const trustStore = createLocalTrustRegistryStore()
+        const store = createCockpitEventStore(
+            [
+                {
+                    kind: "session_hello",
+                    session: {
+                        ...baseSession,
+                        hostId: "host-workhorse",
+                    },
+                },
+            ],
+            { trustStore },
+        )
+
+        expect(store.getSnapshot().sessions[0]?.trust).toMatchObject({
+            status: "unknown",
+            hostId: "host-workhorse",
+            trustedHostLabel: null,
+        })
+
+        trustStore.upsertHost({
+            hostId: "host-workhorse",
+            label: "Workhorse Mac",
+            createdAt: "2026-04-27T16:00:00.000Z",
+            lastSeenAt: "2026-04-27T16:10:00.000Z",
+            status: "trusted",
+        })
+
+        expect(store.getSnapshot().sessions[0]?.trust).toEqual({
+            status: "trusted",
+            hostId: "host-workhorse",
+            hostLabel: "workhorse-mac",
+            trustedHostLabel: "Workhorse Mac",
+            lastSeenAt: "2026-04-27T16:10:00.000Z",
+        })
+
+        trustStore.revokeHost("host-workhorse", "2026-04-27T16:20:00.000Z")
+
+        expect(store.getSnapshot().sessions[0]?.trust.status).toBe("revoked")
+        expect(store.getSnapshot().sessions[0]?.trust.lastSeenAt).toBe("2026-04-27T16:20:00.000Z")
     })
 
     it("keeps stale epoch evidence in the snapshot", () => {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -8,15 +8,19 @@ import type {
     RequestedInput,
     SessionCommand,
     SessionId,
+    SessionTrust,
     SessionTurn,
     StaleCockpitEvent,
 } from "@code-everywhere/contracts"
 import {
+    createDefaultSessionTrust,
     createEmptyCockpitState,
     getAttentionSessionIds,
     getProjectedSessions,
     projectCockpitEvent,
 } from "@code-everywhere/contracts"
+
+import type { LocalTrustRegistrySnapshot, LocalTrustRegistryStore } from "./trust.js"
 
 export type CockpitIngestionSnapshot = {
     eventCount: number
@@ -31,6 +35,10 @@ export type CockpitEventStore = {
     getSnapshot: () => CockpitIngestionSnapshot
     getEvents: () => CockpitProjectionEvent[]
     reset: (events?: CockpitProjectionEvent[]) => CockpitIngestionSnapshot
+}
+
+export type CockpitEventStoreOptions = {
+    trustStore?: LocalTrustRegistryStore
 }
 
 export type CockpitCommandRecord = {
@@ -69,11 +77,14 @@ export type CockpitCommandStoreOptions = {
     initialRecords?: CockpitCommandRecord[]
 }
 
-export const createCockpitEventStore = (initialEvents: CockpitProjectionEvent[] = []): CockpitEventStore => {
+export const createCockpitEventStore = (
+    initialEvents: CockpitProjectionEvent[] = [],
+    options: CockpitEventStoreOptions = {},
+): CockpitEventStore => {
     let events: CockpitProjectionEvent[] = []
     let state = createEmptyCockpitState()
 
-    const getSnapshot = (): CockpitIngestionSnapshot => createSnapshot(state, events.length)
+    const getSnapshot = (): CockpitIngestionSnapshot => createSnapshot(state, events.length, options.trustStore?.getSnapshot())
 
     const ingest = (event: CockpitProjectionEvent): CockpitIngestionSnapshot => {
         const eventCopy = cloneEvent(event)
@@ -185,14 +196,57 @@ export const createCockpitCommandStore = (
     return store
 }
 
-const createSnapshot = (state: CockpitProjectionState, eventCount: number): CockpitIngestionSnapshot => {
-    const clonedState = cloneProjectionState(state)
+const createSnapshot = (
+    state: CockpitProjectionState,
+    eventCount: number,
+    trustSnapshot?: LocalTrustRegistrySnapshot,
+): CockpitIngestionSnapshot => {
+    const clonedState = annotateProjectionStateTrust(cloneProjectionState(state), trustSnapshot)
 
     return {
         eventCount,
         state: clonedState,
         sessions: getProjectedSessions(clonedState).map(cloneProjectedSession),
         attentionSessionIds: getAttentionSessionIds(clonedState),
+    }
+}
+
+const annotateProjectionStateTrust = (
+    state: CockpitProjectionState,
+    trustSnapshot: LocalTrustRegistrySnapshot | undefined,
+): CockpitProjectionState => ({
+    ...state,
+    sessions: Object.fromEntries(
+        Object.entries(state.sessions).map(([sessionId, session]) => [
+            sessionId,
+            {
+                ...session,
+                trust: resolveSessionTrust(session, trustSnapshot),
+            },
+        ]),
+    ),
+})
+
+export const resolveSessionTrust = (
+    session: Pick<ProjectedCockpitSession, "hostId" | "hostLabel">,
+    trustSnapshot: LocalTrustRegistrySnapshot | undefined,
+): SessionTrust => {
+    const defaultTrust = createDefaultSessionTrust(session)
+    if (defaultTrust.hostId === null) {
+        return defaultTrust
+    }
+
+    const hostRecord = trustSnapshot?.hosts.find((host) => host.hostId === defaultTrust.hostId)
+    if (hostRecord === undefined) {
+        return defaultTrust
+    }
+
+    return {
+        status: hostRecord.status,
+        hostId: hostRecord.hostId,
+        hostLabel: session.hostLabel,
+        trustedHostLabel: hostRecord.label,
+        lastSeenAt: hostRecord.lastSeenAt,
     }
 }
 
@@ -255,6 +309,7 @@ const cloneRecord = <Value>(record: Record<string, Value>, cloneValue: (value: V
 
 const cloneProjectedSession = (session: ProjectedCockpitSession): ProjectedCockpitSession => ({
     ...session,
+    trust: { ...session.trust },
     pendingApprovalIds: [...session.pendingApprovalIds],
     pendingInputIds: [...session.pendingInputIds],
     turnIds: [...session.turnIds],

--- a/scripts/smoke-cockpit-web-live-loop.mjs
+++ b/scripts/smoke-cockpit-web-live-loop.mjs
@@ -30,7 +30,7 @@ const run = async () => {
         await assertBrowserState(uiBrowser, session, {
             mode: "Live HTTP",
             state: "No live sessions",
-            detail: "no trusted Every Code sessions",
+            detail: "no Every Code sessions",
         })
 
         await postJson(`${brokerUrl}/events`, { events: createLiveLoopEvents("Smoke broker live loop") })


### PR DESCRIPTION
## Summary
- add projected session trust status with legacy-safe defaults
- derive trust-aware snapshots from the broker local trust registry by hostId
- show compact trust status in the cockpit and document auth-vs-trust separation

## Validation
- pnpm --filter @code-everywhere/contracts test -- projection.test.ts
- pnpm --filter @code-everywhere/server test -- index.test.ts http.test.ts
- pnpm --filter @code-everywhere/web test -- cockpitTransport.test.ts App.test.ts
- pnpm lint:dry-run && pnpm validate
- pnpm smoke:cockpit:web
- manual browser review at http://127.0.0.1:57200/

## Notes
- Sessions without hostId remain valid and are marked unidentified.
- Host ids with no trusted record are unknown, not trusted.
- Broker auth tokens still authorize routes only; they do not affect session trust.