### PR TITLE
Add local trust management routes

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,7 +72,9 @@ operator records. Broker auth tokens remain route authorization only. Apple
 clients can keep device-held secrets in Keychain later, while the local broker
 continues to own the trusted-record list for the local deployment mode. Broker
 snapshots derive session trust from projected `hostId` and the host registry;
-sessions without a host id remain explicit unverified legacy sessions.
+sessions without a host id remain explicit unverified legacy sessions. The local
+broker exposes a narrow trust API for inspecting the registry and upserting or
+revoking host records; it does not store route auth tokens in trust records.
 
 ### Clients
 

--- a/docs/every-code-integration.md
+++ b/docs/every-code-integration.md
@@ -134,6 +134,9 @@ Every Code adapter that consumes them:
   helper exported from the same module
 - `/snapshot` returns projected sessions with `trust.status`; route auth tokens
   authorize broker access but never mark a session trusted
+- local trust records can be inspected with `GET /trust`; trusted host records
+  can be upserted with `POST /trust/hosts`, and hosts can be revoked with
+  `POST /trust/hosts/revoke`
 - web clients pass broker auth with `VITE_COCKPIT_AUTH_TOKEN` when the broker is
   started with a token
 

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -168,12 +168,14 @@ export const startCockpitHttpServer = async (
         throw new CockpitServerCliError("--auth-token or CODE_EVERYWHERE_AUTH_TOKEN is required when binding beyond loopback")
     }
 
-    const stores =
-        options.dataFile === undefined || options.dataFile === null ? undefined : createPersistentCockpitStores(options.dataFile)
     const trustStore =
         options.trustFile === undefined || options.trustFile === null
             ? createLocalTrustRegistryStore()
             : createPersistentLocalTrustRegistryStore(options.trustFile)
+    const stores =
+        options.dataFile === undefined || options.dataFile === null
+            ? undefined
+            : createPersistentCockpitStores(options.dataFile, { eventStoreOptions: { trustStore } })
     const server = createCockpitHttpServer({ ...(stores ?? {}), trustStore, authToken })
     await new Promise<void>((resolve, reject) => {
         const onError = (error: Error) => {

--- a/packages/server/src/http.test.ts
+++ b/packages/server/src/http.test.ts
@@ -114,6 +114,12 @@ describe("cockpit HTTP transport", () => {
             expect(headerResponse.statusCode).toBe(200)
             expect(headerResponse.headers["access-control-allow-headers"]).toContain("authorization")
             expect(headerResponse.headers["access-control-allow-headers"]).toContain("x-code-everywhere-token")
+
+            await expect(
+                sendJson(protectedBaseUrl, "GET", "/trust", undefined, { authorization: "Bearer test-secret" }),
+            ).resolves.toMatchObject({
+                statusCode: 200,
+            })
         } finally {
             await new Promise<void>((resolve, reject) => {
                 protectedServer.close((error) => {
@@ -209,6 +215,73 @@ describe("cockpit HTTP transport", () => {
         } finally {
             await new Promise<void>((resolve) => trustedServer.close(() => resolve()))
         }
+    })
+
+    it("manages trusted host records through local trust routes", async () => {
+        const trustStore = createLocalTrustRegistryStore()
+        const trustServer = createCockpitHttpServer({ trustStore })
+        let trustBaseUrl: string
+
+        try {
+            await new Promise<void>((resolve) => {
+                trustServer.listen(0, "127.0.0.1", resolve)
+            })
+            const address = trustServer.address() as AddressInfo
+            trustBaseUrl = `http://127.0.0.1:${String(address.port)}`
+
+            await expect(sendJson(trustBaseUrl, "GET", "/trust")).resolves.toMatchObject({
+                statusCode: 200,
+                body: {
+                    version: 1,
+                    operator: null,
+                    hosts: [],
+                    devices: [],
+                },
+            })
+
+            const host = {
+                hostId: "host-workhorse",
+                label: "Workhorse Mac",
+                createdAt: "2026-04-29T19:40:00.000Z",
+                lastSeenAt: null,
+                status: "trusted",
+            }
+            await expect(sendJson(trustBaseUrl, "POST", "/trust/hosts", { host })).resolves.toMatchObject({
+                statusCode: 200,
+                body: {
+                    hosts: [host],
+                },
+            })
+
+            await expect(
+                sendJson(trustBaseUrl, "POST", "/trust/hosts/revoke", {
+                    hostId: "host-workhorse",
+                    revokedAt: "2026-04-29T19:45:00.000Z",
+                }),
+            ).resolves.toMatchObject({
+                statusCode: 200,
+                body: {
+                    hosts: [{ ...host, lastSeenAt: "2026-04-29T19:45:00.000Z", status: "revoked" }],
+                },
+            })
+        } finally {
+            await new Promise<void>((resolve) => trustServer.close(() => resolve()))
+        }
+    })
+
+    it("rejects malformed trust management requests", async () => {
+        await expect(sendJson(baseUrl, "POST", "/trust/hosts", { hostId: "host-workhorse" })).resolves.toMatchObject({
+            statusCode: 400,
+            body: { error: "Expected one local host trust record" },
+        })
+        await expect(sendJson(baseUrl, "POST", "/trust/hosts/revoke", { hostId: "host-workhorse" })).resolves.toMatchObject({
+            statusCode: 400,
+            body: { error: "Expected hostId and revokedAt strings" },
+        })
+        await expect(sendJson(baseUrl, "PUT", "/trust", {})).resolves.toMatchObject({
+            statusCode: 405,
+            body: { error: "Method not allowed" },
+        })
     })
 
     it("ingests command outcome events", async () => {

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -25,7 +25,12 @@ import {
     type CockpitEventStore,
     type CockpitIngestionSnapshot,
 } from "./index.js"
-import type { LocalTrustRegistryStore } from "./trust.js"
+import {
+    createLocalTrustRegistryStore,
+    type LocalHostTrustRecord,
+    type LocalTrustRegistrySnapshot,
+    type LocalTrustRegistryStore,
+} from "./trust.js"
 
 export type CockpitHttpHandlerOptions = {
     store?: CockpitEventStore
@@ -37,7 +42,12 @@ export type CockpitHttpHandlerOptions = {
 
 export type CockpitHttpServerOptions = CockpitHttpHandlerOptions
 
-type JsonResponse = CockpitIngestionSnapshot | CockpitCommandSnapshot | CockpitCommandClaim | { error: string }
+type JsonResponse =
+    | CockpitIngestionSnapshot
+    | CockpitCommandSnapshot
+    | CockpitCommandClaim
+    | LocalTrustRegistrySnapshot
+    | { error: string }
 
 const defaultMaxBodyBytes = 1024 * 1024
 const sessionStatusValues = [
@@ -75,17 +85,15 @@ const sessionCommandKindValues = [
 const commandOutcomeStatusValues = ["accepted", "rejected"] as const satisfies readonly CommandOutcome["status"][]
 
 export const createCockpitHttpHandler = (options: CockpitHttpHandlerOptions = {}) => {
+    const trustStore = options.trustStore ?? createLocalTrustRegistryStore()
     const store =
-        options.store ??
-        (options.trustStore === undefined
-            ? createCockpitEventStore()
-            : createCockpitEventStore([], { trustStore: options.trustStore }))
+        options.store ?? (options.trustStore === undefined ? createCockpitEventStore() : createCockpitEventStore([], { trustStore }))
     const commandStore = options.commandStore ?? createCockpitCommandStore()
     const maxBodyBytes = options.maxBodyBytes ?? defaultMaxBodyBytes
     const authToken = normalizeAuthToken(options.authToken)
 
     return (request: IncomingMessage, response: ServerResponse): void => {
-        void routeRequest(request, response, store, commandStore, maxBodyBytes, authToken).catch((error: unknown) => {
+        void routeRequest(request, response, store, commandStore, trustStore, maxBodyBytes, authToken).catch((error: unknown) => {
             if (error instanceof HttpInputError) {
                 writeJson(response, error.statusCode, { error: error.message })
                 return
@@ -104,6 +112,7 @@ const routeRequest = async (
     response: ServerResponse,
     store: CockpitEventStore,
     commandStore: CockpitCommandStore,
+    trustStore: LocalTrustRegistryStore,
     maxBodyBytes: number,
     authToken: string | null,
 ): Promise<void> => {
@@ -186,6 +195,50 @@ const routeRequest = async (
         }
 
         writeJson(response, 200, commandStore.enqueue(command))
+        return
+    }
+
+    if (url.pathname === "/trust") {
+        if (request.method !== "GET") {
+            writeMethodNotAllowed(response, "GET")
+            return
+        }
+
+        writeJson(response, 200, trustStore.getSnapshot())
+        return
+    }
+
+    if (url.pathname === "/trust/hosts") {
+        if (request.method !== "POST") {
+            writeMethodNotAllowed(response, "POST")
+            return
+        }
+
+        const body = await readJsonBody(request, maxBodyBytes)
+        const host = normalizeHostTrustPayload(body)
+        if (host === null) {
+            writeJson(response, 400, { error: "Expected one local host trust record" })
+            return
+        }
+
+        writeJson(response, 200, trustStore.upsertHost(host))
+        return
+    }
+
+    if (url.pathname === "/trust/hosts/revoke") {
+        if (request.method !== "POST") {
+            writeMethodNotAllowed(response, "POST")
+            return
+        }
+
+        const body = await readJsonBody(request, maxBodyBytes)
+        const payload = normalizeHostRevokePayload(body)
+        if (payload === null) {
+            writeJson(response, 400, { error: "Expected hostId and revokedAt strings" })
+            return
+        }
+
+        writeJson(response, 200, trustStore.revokeHost(payload.hostId, payload.revokedAt))
         return
     }
 
@@ -332,6 +385,26 @@ const normalizeCommandClaimPayload = (payload: unknown): { sessionId?: string } 
     return null
 }
 
+const normalizeHostTrustPayload = (payload: unknown): LocalHostTrustRecord | null => {
+    const host = isRecord(payload) && "host" in payload ? payload.host : payload
+    if (!isHostTrustRecord(host)) {
+        return null
+    }
+
+    return { ...host }
+}
+
+const normalizeHostRevokePayload = (payload: unknown): { hostId: string; revokedAt: string } | null => {
+    if (!isRecord(payload) || !hasString(payload, "hostId") || !hasString(payload, "revokedAt")) {
+        return null
+    }
+
+    return {
+        hostId: String(payload.hostId),
+        revokedAt: String(payload.revokedAt),
+    }
+}
+
 const selectCommandPayload = (payload: unknown): unknown => {
     if (isRecord(payload) && "command" in payload) {
         return payload.command
@@ -339,6 +412,14 @@ const selectCommandPayload = (payload: unknown): unknown => {
 
     return payload
 }
+
+const isHostTrustRecord = (value: unknown): value is LocalHostTrustRecord =>
+    isRecord(value) &&
+    hasString(value, "hostId") &&
+    hasString(value, "label") &&
+    hasString(value, "createdAt") &&
+    hasNullableString(value, "lastSeenAt") &&
+    hasEnum(value, "status", ["trusted", "revoked"] as const)
 
 export const isSessionCommand = (value: unknown): value is SessionCommand => {
     if (!isRecord(value) || typeof value.kind !== "string") {

--- a/packages/server/src/persistence.ts
+++ b/packages/server/src/persistence.ts
@@ -9,6 +9,7 @@ import {
     type CockpitCommandRecord,
     type CockpitCommandStore,
     type CockpitEventStore,
+    type CockpitEventStoreOptions,
 } from "./index.js"
 import { isCockpitProjectionEvent, isSessionCommand } from "./http.js"
 import { compactCockpitEvents, defaultCockpitEventRetentionPolicy, type CockpitEventRetentionPolicy } from "./retention.js"
@@ -27,6 +28,7 @@ export type PersistentCockpitStores = {
 export type CockpitPersistenceOptions = {
     writeSnapshot?: (filePath: string, snapshot: CockpitPersistenceSnapshot) => void
     eventRetentionPolicy?: CockpitEventRetentionPolicy | null
+    eventStoreOptions?: CockpitEventStoreOptions
 }
 
 export class CockpitPersistenceError extends Error {}
@@ -45,11 +47,12 @@ export const createPersistentCockpitStores = (
     const eventRetentionPolicy =
         options.eventRetentionPolicy === undefined ? defaultCockpitEventRetentionPolicy : options.eventRetentionPolicy
     const snapshot = readCockpitPersistenceFile(filePath)
-    let eventStore = createCockpitEventStore(snapshot.events)
+    const eventStoreOptions = options.eventStoreOptions
+    let eventStore = createCockpitEventStore(snapshot.events, eventStoreOptions)
     let commandStore = createCockpitCommandStore([], { initialRecords: snapshot.commands })
 
     const restore = (previousSnapshot: CockpitPersistenceSnapshot): void => {
-        eventStore = createCockpitEventStore(previousSnapshot.events)
+        eventStore = createCockpitEventStore(previousSnapshot.events, eventStoreOptions)
         commandStore = createCockpitCommandStore([], { initialRecords: previousSnapshot.commands })
     }
 


### PR DESCRIPTION
## Summary
- add authenticated local trust routes: GET /trust, POST /trust/hosts, POST /trust/hosts/revoke
- keep trust records non-secret and separate from broker route auth
- thread trust store into persisted event stores so snapshots remain trust-aware after loading broker persistence

## Validation
- pnpm --filter @code-everywhere/server test -- http.test.ts cli.test.ts persistence.test.ts
- pnpm lint:dry-run && pnpm validate

## Notes
- This is broker API only; no web/native trust-management UI yet.
- Route auth protects access but still does not mark any host or session trusted.