### PR TITLE
Add cockpit host trust controls

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -64,6 +64,7 @@ import {
     type DraftMap,
 } from "./cockpitDrafts"
 import { describeTransportStatus, useCockpitView, type CockpitTransportStatus } from "./cockpitTransport"
+import { canManageTrust, postRevokedHost, postTrustedHost } from "./cockpitTrust"
 
 const selectedSessionId = "ce-alpha"
 
@@ -181,6 +182,7 @@ export const App = () => {
     const [replyDrafts, setReplyDrafts] = useState<DraftMap>({})
     const [inputAnswerDrafts, setInputAnswerDrafts] = useState<DraftMap>({})
     const [commandLog, setCommandLog] = useState("No command sent yet")
+    const [trustLog, setTrustLog] = useState("No trust action sent yet")
     const fallbackSession = cockpit.sessions[0]
     const activeSession =
         fallbackSession === undefined
@@ -247,6 +249,27 @@ export const App = () => {
             })
     }
 
+    const dispatchTrustAction = (label: string, session: CockpitSession, action: "trust" | "revoke") => {
+        if (!canManageTrust(cockpitView.transport)) {
+            setTrustLog(`${label} requires a live HTTP broker`)
+            return
+        }
+
+        setTrustLog(`Sending ${label} for ${session.hostLabel}`)
+        const request = action === "trust" ? postTrustedHost : postRevokedHost
+        void request(cockpitView.transport.url, session)
+            .then((snapshot) => {
+                const host =
+                    session.hostId === undefined
+                        ? undefined
+                        : snapshot.hosts.find((candidate) => candidate.hostId === session.hostId)
+                setTrustLog(`${label} saved for ${session.hostLabel}; ${host?.status ?? "host record updated"}`)
+            })
+            .catch((error: unknown) => {
+                setTrustLog(`${label} failed: ${error instanceof Error ? error.message : "Unable to update trust"}`)
+            })
+    }
+
     const selectSession = (sessionId: string) => {
         setActiveSessionId(sessionId)
         setActivePendingItemId(null)
@@ -310,9 +333,12 @@ export const App = () => {
                                 setInputAnswer={setInputAnswer}
                                 setInputNote={setInputNote}
                                 commandLog={commandLog}
+                                trustLog={trustLog}
                                 commandHistory={activeCommandHistory}
                                 commandOutcomeSummary={activeCommandOutcomeSummary}
                                 dispatchCommand={dispatchCommand}
+                                dispatchTrustAction={dispatchTrustAction}
+                                transport={cockpitView.transport}
                             />
                         </>
                     )}
@@ -638,9 +664,12 @@ type ActionRailProps = {
     setInputAnswer: (questionId: string, value: string) => void
     setInputNote: (value: string) => void
     commandLog: string
+    trustLog: string
     commandHistory: CommandHistoryEntry[]
     commandOutcomeSummary: CommandOutcomeSummary
     dispatchCommand: (label: string, command: SessionCommand) => void
+    dispatchTrustAction: (label: string, session: CockpitSession, action: "trust" | "revoke") => void
+    transport: CockpitTransportStatus
 }
 
 const ActionRail = ({
@@ -652,9 +681,12 @@ const ActionRail = ({
     setInputAnswer,
     setInputNote,
     commandLog,
+    trustLog,
     commandHistory,
     commandOutcomeSummary,
     dispatchCommand,
+    dispatchTrustAction,
+    transport,
 }: ActionRailProps) => (
     <aside className="action-rail" aria-label="Pending work and actions">
         <section className="panel work-panel priority-panel">
@@ -685,6 +717,13 @@ const ActionRail = ({
                 />
             )}
         </section>
+
+        <TrustManagementPanel
+            session={session}
+            transport={transport}
+            trustLog={trustLog}
+            dispatchTrustAction={dispatchTrustAction}
+        />
 
         <section className="panel work-panel">
             <div className="panel-heading compact-heading">
@@ -724,6 +763,67 @@ const ActionRail = ({
         </section>
     </aside>
 )
+
+const TrustManagementPanel = ({
+    session,
+    transport,
+    trustLog,
+    dispatchTrustAction,
+}: {
+    session: CockpitSession
+    transport: CockpitTransportStatus
+    trustLog: string
+    dispatchTrustAction: (label: string, session: CockpitSession, action: "trust" | "revoke") => void
+}) => {
+    const hostId = session.hostId?.trim()
+    const hasHostId = hostId !== undefined && hostId !== ""
+    const isLive = canManageTrust(transport)
+    const canTrust = hasHostId && isLive && session.trust.status !== "trusted"
+    const canRevoke = hasHostId && isLive && session.trust.status === "trusted"
+
+    return (
+        <section className="panel work-panel trust-panel" aria-label="Local trust">
+            <div className="panel-heading compact-heading">
+                <div>
+                    <p className="eyebrow">Local trust</p>
+                    <h2>Host record</h2>
+                </div>
+                <TrustPill trust={session.trust} compact />
+            </div>
+            <div className="trust-card">
+                <div>
+                    <span>Host</span>
+                    <strong>{session.hostLabel}</strong>
+                    <p>{hostId ?? "No stable host id published"}</p>
+                </div>
+                <div className="trust-actions">
+                    <button
+                        className="primary-button"
+                        type="button"
+                        disabled={!canTrust}
+                        onClick={() => dispatchTrustAction("Trust host", session, "trust")}
+                    >
+                        <ShieldCheck size={16} />
+                        Trust
+                    </button>
+                    <button
+                        className="quiet-button danger"
+                        type="button"
+                        disabled={!canRevoke}
+                        onClick={() => dispatchTrustAction("Revoke host", session, "revoke")}
+                    >
+                        <ShieldAlert size={16} />
+                        Revoke
+                    </button>
+                </div>
+                <div className="mock-log" aria-live="polite">
+                    <span>Trust status</span>
+                    <p>{trustLog}</p>
+                </div>
+            </div>
+        </section>
+    )
+}
 
 const ApprovalCard = ({
     approval,

--- a/apps/web/src/cockpitTrust.test.ts
+++ b/apps/web/src/cockpitTrust.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest"
+
+import { cockpitFixture } from "./cockpitData"
+import { canManageTrust, createTrustUrl, postRevokedHost, postTrustedHost } from "./cockpitTrust"
+
+describe("cockpit trust client", () => {
+    const session = getFixtureSession()
+    const now = () => new Date("2026-04-29T19:50:00.000Z")
+    const trustSnapshot = {
+        version: 1,
+        operator: null,
+        hosts: [
+            {
+                hostId: session.hostId,
+                label: session.hostLabel,
+                createdAt: "2026-04-29T19:50:00.000Z",
+                lastSeenAt: "2026-04-29T19:50:00.000Z",
+                status: "trusted",
+            },
+        ],
+        devices: [],
+    }
+
+    it("builds trust URLs from a configured transport root", () => {
+        expect(createTrustUrl("http://127.0.0.1:4789")).toBe("http://127.0.0.1:4789/trust")
+        expect(createTrustUrl("http://127.0.0.1:4789/", "/hosts")).toBe("http://127.0.0.1:4789/trust/hosts")
+    })
+
+    it("allows trust management only for live HTTP snapshots", () => {
+        expect(canManageTrust({ mode: "fixture", url: null, updatedAt: null, error: null })).toBe(false)
+        expect(canManageTrust({ mode: "connecting", url: "http://127.0.0.1:4789", updatedAt: null, error: null })).toBe(false)
+        expect(canManageTrust({ mode: "fallback", url: "http://127.0.0.1:4789", updatedAt: null, error: "offline" })).toBe(false)
+        expect(canManageTrust({ mode: "live", url: "http://127.0.0.1:4789", updatedAt: "now", error: null })).toBe(true)
+    })
+
+    it("posts trusted host records as JSON", async () => {
+        const requests: { url: string; init: RequestInit | undefined }[] = []
+        const fetchImpl: Parameters<typeof postTrustedHost>[3] = (input, init) => {
+            requests.push({ url: toRequestUrl(input), init })
+            return Promise.resolve(new Response(JSON.stringify(trustSnapshot), { status: 200 }))
+        }
+
+        await expect(postTrustedHost("http://127.0.0.1:4789", session, now, fetchImpl)).resolves.toMatchObject({
+            hosts: [{ hostId: session.hostId, status: "trusted" }],
+        })
+        expect(requests[0]?.url).toBe("http://127.0.0.1:4789/trust/hosts")
+        expect(requests[0]?.init).toMatchObject({
+            method: "POST",
+            body: JSON.stringify({
+                host: {
+                    hostId: session.hostId,
+                    label: session.hostLabel,
+                    createdAt: "2026-04-29T19:50:00.000Z",
+                    lastSeenAt: "2026-04-29T19:50:00.000Z",
+                    status: "trusted",
+                },
+            }),
+        })
+    })
+
+    it("posts host revocations as JSON", async () => {
+        const requests: { url: string; init: RequestInit | undefined }[] = []
+        const fetchImpl: Parameters<typeof postRevokedHost>[3] = (input, init) => {
+            requests.push({ url: toRequestUrl(input), init })
+            return Promise.resolve(
+                new Response(
+                    JSON.stringify({
+                        ...trustSnapshot,
+                        hosts: [{ ...trustSnapshot.hosts[0], status: "revoked" }],
+                    }),
+                    { status: 200 },
+                ),
+            )
+        }
+
+        await expect(postRevokedHost("http://127.0.0.1:4789", session, now, fetchImpl)).resolves.toMatchObject({
+            hosts: [{ hostId: session.hostId, status: "revoked" }],
+        })
+        expect(requests[0]?.url).toBe("http://127.0.0.1:4789/trust/hosts/revoke")
+        expect(requests[0]?.init).toMatchObject({
+            method: "POST",
+            body: JSON.stringify({ hostId: session.hostId, revokedAt: "2026-04-29T19:50:00.000Z" }),
+        })
+    })
+
+    it("rejects missing host ids and malformed responses", async () => {
+        const missingHostSession = { ...session }
+        delete missingHostSession.hostId
+        const failingFetch: Parameters<typeof postTrustedHost>[3] = () => Promise.resolve(new Response("Nope", { status: 400 }))
+        const malformedFetch: Parameters<typeof postTrustedHost>[3] = () =>
+            Promise.resolve(new Response(JSON.stringify({ version: 1, hosts: [] }), { status: 200 }))
+
+        await expect(postTrustedHost("http://127.0.0.1:4789", missingHostSession, now, failingFetch)).rejects.toThrow(
+            "Session does not publish a host id",
+        )
+        await expect(postTrustedHost("http://127.0.0.1:4789", session, now, failingFetch)).rejects.toThrow(
+            "Cockpit trust request failed with 400",
+        )
+        await expect(postTrustedHost("http://127.0.0.1:4789", session, now, malformedFetch)).rejects.toThrow(
+            "Cockpit trust response did not match the expected shape",
+        )
+    })
+})
+
+const getFixtureSession = () => {
+    const session = cockpitFixture.sessions[0]
+    if (session === undefined) {
+        throw new Error("expected fixture session")
+    }
+
+    return session
+}
+
+const toRequestUrl = (input: RequestInfo | URL): string => {
+    if (typeof input === "string") {
+        return input
+    }
+
+    return input instanceof URL ? input.toString() : input.url
+}

--- a/apps/web/src/cockpitTrust.ts
+++ b/apps/web/src/cockpitTrust.ts
@@ -1,0 +1,117 @@
+import type { LocalHostTrustRecord, LocalTrustRegistrySnapshot } from "@code-everywhere/server/trust"
+
+import type { CockpitSession } from "./cockpitData"
+import type { CockpitTransportStatus } from "./cockpitTransport"
+
+type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+
+const configuredAuthToken = (() => {
+    const authToken: unknown = import.meta.env.VITE_COCKPIT_AUTH_TOKEN
+    return typeof authToken === "string" ? normalizeAuthToken(authToken) : null
+})()
+
+export const postTrustedHost = async (
+    transportUrl: string,
+    session: CockpitSession,
+    now: () => Date = () => new Date(),
+    fetchImpl: FetchLike = globalThis.fetch,
+): Promise<LocalTrustRegistrySnapshot> => {
+    if (session.hostId === undefined || session.hostId.trim() === "") {
+        throw new Error("Session does not publish a host id")
+    }
+
+    const timestamp = now().toISOString()
+    const host: LocalHostTrustRecord = {
+        hostId: session.hostId,
+        label: session.hostLabel,
+        createdAt:
+            session.trust.status === "trusted" || session.trust.status === "revoked"
+                ? (session.trust.lastSeenAt ?? timestamp)
+                : timestamp,
+        lastSeenAt: timestamp,
+        status: "trusted",
+    }
+
+    return postTrustJson(transportUrl, "hosts", { host }, fetchImpl)
+}
+
+export const postRevokedHost = async (
+    transportUrl: string,
+    session: CockpitSession,
+    now: () => Date = () => new Date(),
+    fetchImpl: FetchLike = globalThis.fetch,
+): Promise<LocalTrustRegistrySnapshot> => {
+    if (session.hostId === undefined || session.hostId.trim() === "") {
+        throw new Error("Session does not publish a host id")
+    }
+
+    return postTrustJson(transportUrl, "hosts/revoke", { hostId: session.hostId, revokedAt: now().toISOString() }, fetchImpl)
+}
+
+export const createTrustUrl = (transportUrl: string, path = ""): string => {
+    const normalizedPath = path.replace(/^\/+/, "")
+    return `${transportUrl.replace(/\/+$/, "")}/trust${normalizedPath === "" ? "" : `/${normalizedPath}`}`
+}
+
+export const canManageTrust = (
+    transport: CockpitTransportStatus,
+): transport is CockpitTransportStatus & { mode: "live"; url: string } => transport.mode === "live" && transport.url !== null
+
+const postTrustJson = async (
+    transportUrl: string,
+    path: string,
+    body: unknown,
+    fetchImpl: FetchLike,
+): Promise<LocalTrustRegistrySnapshot> => {
+    const response = await fetchImpl(createTrustUrl(transportUrl, path), {
+        method: "POST",
+        cache: "no-store",
+        headers: {
+            accept: "application/json",
+            "content-type": "application/json",
+            ...createAuthHeaders(configuredAuthToken),
+        },
+        body: JSON.stringify(body),
+    })
+
+    if (!response.ok) {
+        throw new Error(`Cockpit trust request failed with ${String(response.status)}`)
+    }
+
+    const payload = (await response.json()) as unknown
+    if (!isLocalTrustRegistrySnapshot(payload)) {
+        throw new Error("Cockpit trust response did not match the expected shape")
+    }
+
+    return payload
+}
+
+function normalizeAuthToken(authToken: string): string | null {
+    const normalized = authToken.trim()
+    return normalized === "" ? null : normalized
+}
+
+function createAuthHeaders(authToken: string | null): Record<string, string> {
+    return authToken === null ? {} : { authorization: `Bearer ${authToken}` }
+}
+
+const isLocalTrustRegistrySnapshot = (value: unknown): value is LocalTrustRegistrySnapshot =>
+    isRecord(value) &&
+    value.version === 1 &&
+    (value.operator === null || isRecord(value.operator)) &&
+    isArrayOf(value.hosts, isHostTrustRecord) &&
+    Array.isArray(value.devices)
+
+const isHostTrustRecord = (value: unknown): value is LocalHostTrustRecord =>
+    isRecord(value) &&
+    typeof value.hostId === "string" &&
+    typeof value.label === "string" &&
+    typeof value.createdAt === "string" &&
+    (value.lastSeenAt === null || typeof value.lastSeenAt === "string") &&
+    (value.status === "trusted" || value.status === "revoked")
+
+const isArrayOf = <Value>(value: unknown, guard: (entry: unknown) => entry is Value): value is Value[] =>
+    Array.isArray(value) && value.every(guard)
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === "object" && value !== null && !Array.isArray(value)

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -913,6 +913,7 @@ input:focus {
 .work-panel > .panel-heading,
 .work-panel > .command-grid,
 .mock-log,
+.trust-card,
 .epoch-note,
 .empty-state,
 .decision-card {
@@ -927,6 +928,55 @@ input:focus {
 
 .priority-panel .panel-heading h2 {
     color: var(--fg-1);
+}
+
+.trust-card {
+    display: grid;
+    gap: 10px;
+    margin-top: 10px;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    background: var(--bg-elevated);
+    padding: 12px;
+}
+
+.trust-card > div:first-child {
+    display: grid;
+    gap: 3px;
+    min-width: 0;
+}
+
+.trust-card > div:first-child > span {
+    color: var(--fg-3);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.trust-card strong,
+.trust-card p {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.trust-card strong {
+    color: var(--fg-1);
+    font-size: 13px;
+}
+
+.trust-card p {
+    margin: 0;
+    color: var(--fg-3);
+    font-family: var(--font-mono);
+    font-size: 11px;
+}
+
+.trust-actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
 }
 
 .decision-card {
@@ -1307,6 +1357,13 @@ legend {
 .icon-button:hover {
     background: var(--surface-hover);
     color: var(--fg-1);
+}
+
+.primary-button:disabled,
+.quiet-button:disabled {
+    cursor: not-allowed;
+    opacity: 0.48;
+    filter: none;
 }
 
 .primary-button:focus,

--- a/scripts/smoke-cockpit-web-live-loop.mjs
+++ b/scripts/smoke-cockpit-web-live-loop.mjs
@@ -43,6 +43,9 @@ const run = async () => {
             detail: "Broker/web smoke step complete.",
         })
 
+        await clickFirstCommandButton(uiBrowser, session, "Trust")
+        await waitForTrustedHost(brokerUrl, "smoke-host")
+
         await clickFirstCommandButton(uiBrowser, session, "Status")
         await waitForCommand(brokerUrl, "status_request")
         await clickFirstCommandButton(uiBrowser, session, "Pause")
@@ -288,6 +291,19 @@ const waitForCommand = async (brokerUrl, commandKind) => {
     throw new Error(`Timed out waiting for ${commandKind} command`)
 }
 
+const waitForTrustedHost = async (brokerUrl, hostId) => {
+    const startedAt = Date.now()
+    while (Date.now() - startedAt < 10000) {
+        const snapshot = await getJson(`${brokerUrl}/trust`)
+        if (snapshot.hosts.some((host) => host.hostId === hostId && host.status === "trusted")) {
+            return
+        }
+        await delay(100)
+    }
+
+    throw new Error(`Timed out waiting for trusted host ${hostId}`)
+}
+
 const runCommand = async (command, args) =>
     new Promise((resolve, reject) => {
         const child = spawn(command, args, {
@@ -319,6 +335,7 @@ const createLiveLoopEvents = (summary) => [
         session: {
             sessionId: "smoke-live-session",
             sessionEpoch: "smoke-live-epoch",
+            hostId: "smoke-host",
             hostLabel: "Smoke Host",
             cwd: "/tmp/code-everywhere-web-smoke",
             branch: "main",


### PR DESCRIPTION
## Summary
- add a web cockpit trust client for live broker `POST /trust/hosts` and revoke requests
- add a compact active-session Local trust panel with Trust/Revoke actions and disabled states for non-live or missing-host sessions
- extend the web smoke to publish a host id, click Trust, and verify the broker trust registry updates

## Validation
- `pnpm lint:dry-run && pnpm validate && pnpm smoke:cockpit:web`
- contracts: 14 tests passed
- server: 52 tests passed
- web: 37 tests passed
- smoke: passed at `http://127.0.0.1:61776` using broker `http://127.0.0.1:61775`
- manual browser review at `http://127.0.0.1:59500/`: no horizontal overflow; trust controls/action rail readable
