### PR TITLE
Add cockpit trust registry review

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -8,6 +8,7 @@ import type {
     TurnStatus,
     TurnStep,
 } from "@code-everywhere/contracts"
+import type { LocalHostTrustRecord, LocalTrustRegistrySnapshot } from "@code-everywhere/server/trust"
 import {
     AlertCircle,
     Bell,
@@ -33,7 +34,7 @@ import {
     TerminalSquare,
     X,
 } from "lucide-react"
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 
 import { canPostCockpitCommand, postCockpitCommand } from "./cockpitCommands"
 import {
@@ -64,7 +65,7 @@ import {
     type DraftMap,
 } from "./cockpitDrafts"
 import { describeTransportStatus, useCockpitView, type CockpitTransportStatus } from "./cockpitTransport"
-import { canManageTrust, postRevokedHost, postTrustedHost } from "./cockpitTrust"
+import { canManageTrust, fetchLocalTrustRegistry, postRevokedHost, postRevokedHostId, postTrustedHost } from "./cockpitTrust"
 
 const selectedSessionId = "ce-alpha"
 
@@ -74,6 +75,12 @@ type CockpitStateSurface = {
     tone: "info" | "warning" | "success"
     title: string
     detail: string
+}
+
+type TrustRegistryState = {
+    snapshot: LocalTrustRegistrySnapshot | null
+    status: "unavailable" | "loading" | "ready" | "error"
+    message: string
 }
 
 const statusIcon: Record<SessionStatus, IconComponent> = {
@@ -183,6 +190,11 @@ export const App = () => {
     const [inputAnswerDrafts, setInputAnswerDrafts] = useState<DraftMap>({})
     const [commandLog, setCommandLog] = useState("No command sent yet")
     const [trustLog, setTrustLog] = useState("No trust action sent yet")
+    const [trustRegistry, setTrustRegistry] = useState<TrustRegistryState>({
+        snapshot: null,
+        status: "unavailable",
+        message: "Connect to a live broker to review local trust records.",
+    })
     const fallbackSession = cockpit.sessions[0]
     const activeSession =
         fallbackSession === undefined
@@ -205,6 +217,49 @@ export const App = () => {
     const reply = getDraftValue(replyDrafts, activeSession?.sessionId)
     const inputAnswerValues = getRequestedInputAnswerValues(inputAnswerDrafts, activeInput)
     const inputNote = getRequestedInputNoteValue(inputAnswerDrafts, activeInput)
+
+    useEffect(() => {
+        if (!canManageTrust(cockpitView.transport)) {
+            setTrustRegistry((current) => ({
+                snapshot: current.snapshot,
+                status: "unavailable",
+                message:
+                    current.snapshot === null
+                        ? "Connect to a live broker to review local trust records."
+                        : "Showing last loaded trust records while the broker is unavailable.",
+            }))
+            return undefined
+        }
+
+        let isActive = true
+        const transportUrl = cockpitView.transport.url
+        setTrustRegistry((current) => ({
+            snapshot: current.snapshot,
+            status: current.snapshot === null ? "loading" : "ready",
+            message: current.snapshot === null ? "Loading local trust records..." : "Local trust records loaded.",
+        }))
+        void fetchLocalTrustRegistry(transportUrl)
+            .then((snapshot) => {
+                if (!isActive) {
+                    return
+                }
+                setTrustRegistry({ snapshot, status: "ready", message: "Local trust records loaded." })
+            })
+            .catch((error: unknown) => {
+                if (!isActive) {
+                    return
+                }
+                setTrustRegistry((current) => ({
+                    snapshot: current.snapshot,
+                    status: "error",
+                    message: error instanceof Error ? error.message : "Unable to load local trust records.",
+                }))
+            })
+
+        return () => {
+            isActive = false
+        }
+    }, [cockpitView.transport])
 
     const setReply = (value: string) => {
         if (activeSession === undefined) {
@@ -263,10 +318,29 @@ export const App = () => {
                     session.hostId === undefined
                         ? undefined
                         : snapshot.hosts.find((candidate) => candidate.hostId === session.hostId)
+                setTrustRegistry({ snapshot, status: "ready", message: "Local trust records loaded." })
                 setTrustLog(`${label} saved for ${session.hostLabel}; ${host?.status ?? "host record updated"}`)
             })
             .catch((error: unknown) => {
                 setTrustLog(`${label} failed: ${error instanceof Error ? error.message : "Unable to update trust"}`)
+            })
+    }
+
+    const dispatchTrustHostRevoke = (host: LocalHostTrustRecord) => {
+        if (!canManageTrust(cockpitView.transport)) {
+            setTrustLog(`Revoke host requires a live HTTP broker`)
+            return
+        }
+
+        setTrustLog(`Sending revoke for ${host.label}`)
+        void postRevokedHostId(cockpitView.transport.url, host.hostId)
+            .then((snapshot) => {
+                const updatedHost = snapshot.hosts.find((candidate) => candidate.hostId === host.hostId)
+                setTrustRegistry({ snapshot, status: "ready", message: "Local trust records loaded." })
+                setTrustLog(`Revoke host saved for ${host.label}; ${updatedHost?.status ?? "host record updated"}`)
+            })
+            .catch((error: unknown) => {
+                setTrustLog(`Revoke host failed: ${error instanceof Error ? error.message : "Unable to update trust"}`)
             })
     }
 
@@ -338,6 +412,8 @@ export const App = () => {
                                 commandOutcomeSummary={activeCommandOutcomeSummary}
                                 dispatchCommand={dispatchCommand}
                                 dispatchTrustAction={dispatchTrustAction}
+                                dispatchTrustHostRevoke={dispatchTrustHostRevoke}
+                                trustRegistry={trustRegistry}
                                 transport={cockpitView.transport}
                             />
                         </>
@@ -669,6 +745,8 @@ type ActionRailProps = {
     commandOutcomeSummary: CommandOutcomeSummary
     dispatchCommand: (label: string, command: SessionCommand) => void
     dispatchTrustAction: (label: string, session: CockpitSession, action: "trust" | "revoke") => void
+    dispatchTrustHostRevoke: (host: LocalHostTrustRecord) => void
+    trustRegistry: TrustRegistryState
     transport: CockpitTransportStatus
 }
 
@@ -686,6 +764,8 @@ const ActionRail = ({
     commandOutcomeSummary,
     dispatchCommand,
     dispatchTrustAction,
+    dispatchTrustHostRevoke,
+    trustRegistry,
     transport,
 }: ActionRailProps) => (
     <aside className="action-rail" aria-label="Pending work and actions">
@@ -723,6 +803,8 @@ const ActionRail = ({
             transport={transport}
             trustLog={trustLog}
             dispatchTrustAction={dispatchTrustAction}
+            dispatchTrustHostRevoke={dispatchTrustHostRevoke}
+            trustRegistry={trustRegistry}
         />
 
         <section className="panel work-panel">
@@ -769,11 +851,15 @@ const TrustManagementPanel = ({
     transport,
     trustLog,
     dispatchTrustAction,
+    dispatchTrustHostRevoke,
+    trustRegistry,
 }: {
     session: CockpitSession
     transport: CockpitTransportStatus
     trustLog: string
     dispatchTrustAction: (label: string, session: CockpitSession, action: "trust" | "revoke") => void
+    dispatchTrustHostRevoke: (host: LocalHostTrustRecord) => void
+    trustRegistry: TrustRegistryState
 }) => {
     const hostId = session.hostId?.trim()
     const hasHostId = hostId !== undefined && hostId !== ""
@@ -820,10 +906,86 @@ const TrustManagementPanel = ({
                     <span>Trust status</span>
                     <p>{trustLog}</p>
                 </div>
+                <TrustRegistryList
+                    registry={trustRegistry}
+                    isLive={isLive}
+                    activeHostId={hostId}
+                    onRevokeHost={dispatchTrustHostRevoke}
+                />
             </div>
         </section>
     )
 }
+
+const TrustRegistryList = ({
+    registry,
+    isLive,
+    activeHostId,
+    onRevokeHost,
+}: {
+    registry: TrustRegistryState
+    isLive: boolean
+    activeHostId: string | undefined
+    onRevokeHost: (host: LocalHostTrustRecord) => void
+}) => {
+    const hosts = registry.snapshot?.hosts ?? []
+    const sortedHosts = [...hosts].sort(compareTrustHosts)
+
+    return (
+        <div className="trust-registry" aria-label="Known host trust records">
+            <div className="trust-registry-heading">
+                <span>Known hosts</span>
+                <strong>{hosts.length}</strong>
+            </div>
+            {sortedHosts.length === 0 ? (
+                <p className="trust-registry-empty">{registry.message}</p>
+            ) : (
+                <div className="trust-record-list">
+                    {sortedHosts.map((host) => (
+                        <TrustRegistryRow
+                            key={host.hostId}
+                            host={host}
+                            isActiveHost={activeHostId === host.hostId}
+                            canRevoke={isLive && host.status === "trusted"}
+                            onRevokeHost={onRevokeHost}
+                        />
+                    ))}
+                </div>
+            )}
+        </div>
+    )
+}
+
+const TrustRegistryRow = ({
+    host,
+    isActiveHost,
+    canRevoke,
+    onRevokeHost,
+}: {
+    host: LocalHostTrustRecord
+    isActiveHost: boolean
+    canRevoke: boolean
+    onRevokeHost: (host: LocalHostTrustRecord) => void
+}) => (
+    <div className={`trust-record-row is-${host.status} ${isActiveHost ? "is-active-host" : ""}`}>
+        <div>
+            <strong>{host.label}</strong>
+            <p>{host.hostId}</p>
+            <small>{formatTrustRecordTime(host)}</small>
+        </div>
+        <span className={`trust-record-status is-${host.status}`}>{host.status}</span>
+        <button
+            className="icon-button danger"
+            type="button"
+            disabled={!canRevoke}
+            title={`Revoke ${host.label}`}
+            aria-label={`Revoke ${host.label}`}
+            onClick={() => onRevokeHost(host)}
+        >
+            <ShieldAlert size={14} />
+        </button>
+    </div>
+)
 
 const ApprovalCard = ({
     approval,
@@ -1227,3 +1389,19 @@ const formatTime = (iso: string): string =>
         hour: "numeric",
         minute: "2-digit",
     }).format(new Date(iso))
+
+const compareTrustHosts = (left: LocalHostTrustRecord, right: LocalHostTrustRecord): number => {
+    if (left.status !== right.status) {
+        return left.status === "trusted" ? -1 : 1
+    }
+
+    return getTrustRecordTimestamp(right) - getTrustRecordTimestamp(left)
+}
+
+const formatTrustRecordTime = (host: LocalHostTrustRecord): string => {
+    const timestamp = host.lastSeenAt ?? host.createdAt
+    const label = host.lastSeenAt === null ? "Created" : "Last seen"
+    return `${label} ${formatTime(timestamp)}`
+}
+
+const getTrustRecordTimestamp = (host: LocalHostTrustRecord): number => new Date(host.lastSeenAt ?? host.createdAt).getTime()

--- a/apps/web/src/cockpitTrust.test.ts
+++ b/apps/web/src/cockpitTrust.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "vitest"
 
 import { cockpitFixture } from "./cockpitData"
-import { canManageTrust, createTrustUrl, postRevokedHost, postTrustedHost } from "./cockpitTrust"
+import {
+    canManageTrust,
+    createTrustUrl,
+    fetchLocalTrustRegistry,
+    postRevokedHost,
+    postRevokedHostId,
+    postTrustedHost,
+} from "./cockpitTrust"
 
 describe("cockpit trust client", () => {
     const session = getFixtureSession()
@@ -83,6 +90,31 @@ describe("cockpit trust client", () => {
         })
     })
 
+    it("fetches and revokes known host records by host id", async () => {
+        const requests: { url: string; init: RequestInit | undefined }[] = []
+        const fetchImpl: Parameters<typeof fetchLocalTrustRegistry>[1] = (input, init) => {
+            requests.push({ url: toRequestUrl(input), init })
+            return Promise.resolve(new Response(JSON.stringify(trustSnapshot), { status: 200 }))
+        }
+
+        await expect(fetchLocalTrustRegistry("http://127.0.0.1:4789", fetchImpl)).resolves.toMatchObject({
+            hosts: [{ hostId: session.hostId, status: "trusted" }],
+        })
+        await expect(postRevokedHostId("http://127.0.0.1:4789", " host-alpha ", now, fetchImpl)).resolves.toMatchObject({
+            hosts: [{ hostId: session.hostId, status: "trusted" }],
+        })
+        await expect(postRevokedHostId("http://127.0.0.1:4789", " ", now, fetchImpl)).rejects.toThrow("Host id is required")
+
+        expect(requests.map((request) => request.url)).toEqual([
+            "http://127.0.0.1:4789/trust",
+            "http://127.0.0.1:4789/trust/hosts/revoke",
+        ])
+        expect(requests[1]?.init).toMatchObject({
+            method: "POST",
+            body: JSON.stringify({ hostId: "host-alpha", revokedAt: "2026-04-29T19:50:00.000Z" }),
+        })
+    })
+
     it("rejects missing host ids and malformed responses", async () => {
         const missingHostSession = { ...session }
         delete missingHostSession.hostId
@@ -97,6 +129,12 @@ describe("cockpit trust client", () => {
             "Cockpit trust request failed with 400",
         )
         await expect(postTrustedHost("http://127.0.0.1:4789", session, now, malformedFetch)).rejects.toThrow(
+            "Cockpit trust response did not match the expected shape",
+        )
+        await expect(fetchLocalTrustRegistry("http://127.0.0.1:4789", failingFetch)).rejects.toThrow(
+            "Cockpit trust request failed with 400",
+        )
+        await expect(fetchLocalTrustRegistry("http://127.0.0.1:4789", malformedFetch)).rejects.toThrow(
             "Cockpit trust response did not match the expected shape",
         )
     })

--- a/apps/web/src/cockpitTrust.ts
+++ b/apps/web/src/cockpitTrust.ts
@@ -48,6 +48,44 @@ export const postRevokedHost = async (
     return postTrustJson(transportUrl, "hosts/revoke", { hostId: session.hostId, revokedAt: now().toISOString() }, fetchImpl)
 }
 
+export const postRevokedHostId = async (
+    transportUrl: string,
+    hostId: string,
+    now: () => Date = () => new Date(),
+    fetchImpl: FetchLike = globalThis.fetch,
+): Promise<LocalTrustRegistrySnapshot> => {
+    const normalizedHostId = hostId.trim()
+    if (normalizedHostId === "") {
+        throw new Error("Host id is required")
+    }
+
+    return postTrustJson(transportUrl, "hosts/revoke", { hostId: normalizedHostId, revokedAt: now().toISOString() }, fetchImpl)
+}
+
+export const fetchLocalTrustRegistry = async (
+    transportUrl: string,
+    fetchImpl: FetchLike = globalThis.fetch,
+): Promise<LocalTrustRegistrySnapshot> => {
+    const response = await fetchImpl(createTrustUrl(transportUrl), {
+        cache: "no-store",
+        headers: {
+            accept: "application/json",
+            ...createAuthHeaders(configuredAuthToken),
+        },
+    })
+
+    if (!response.ok) {
+        throw new Error(`Cockpit trust request failed with ${String(response.status)}`)
+    }
+
+    const payload = (await response.json()) as unknown
+    if (!isLocalTrustRegistrySnapshot(payload)) {
+        throw new Error("Cockpit trust response did not match the expected shape")
+    }
+
+    return payload
+}
+
 export const createTrustUrl = (transportUrl: string, path = ""): string => {
     const normalizedPath = path.replace(/^\/+/, "")
     return `${transportUrl.replace(/\/+$/, "")}/trust${normalizedPath === "" ? "" : `/${normalizedPath}`}`

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -979,6 +979,102 @@ input:focus {
     gap: 8px;
 }
 
+.trust-registry {
+    display: grid;
+    gap: 8px;
+    border-top: 1px solid var(--border-subtle);
+    padding-top: 10px;
+}
+
+.trust-registry-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.trust-registry-heading span {
+    color: var(--fg-3);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.trust-registry-heading strong {
+    display: inline-grid;
+    min-width: 22px;
+    height: 22px;
+    place-items: center;
+    border: 1px solid var(--border-default);
+    border-radius: 999px;
+    background: var(--bg-base);
+    color: var(--fg-2);
+    font-size: 11px;
+}
+
+.trust-registry-empty {
+    color: var(--fg-3);
+    font-size: 12px;
+    white-space: normal;
+}
+
+.trust-record-list {
+    display: grid;
+    gap: 6px;
+}
+
+.trust-record-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto 30px;
+    align-items: center;
+    gap: 8px;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-sm);
+    background: var(--bg-base);
+    padding: 8px;
+}
+
+.trust-record-row.is-active-host {
+    border-color: var(--blue-500);
+}
+
+.trust-record-row > div {
+    display: grid;
+    min-width: 0;
+    gap: 2px;
+}
+
+.trust-record-row small {
+    overflow: hidden;
+    color: var(--fg-3);
+    font-size: 11px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.trust-record-status {
+    border: 1px solid var(--border-default);
+    border-radius: 999px;
+    padding: 3px 7px;
+    color: var(--fg-2);
+    font-size: 10px;
+    font-weight: 800;
+    text-transform: uppercase;
+}
+
+.trust-record-status.is-trusted {
+    border-color: rgba(21, 128, 61, 0.24);
+    background: rgba(220, 252, 231, 0.92);
+    color: #166534;
+}
+
+.trust-record-status.is-revoked {
+    border-color: rgba(185, 28, 28, 0.24);
+    background: rgba(254, 226, 226, 0.9);
+    color: #991b1b;
+}
+
 .decision-card {
     position: relative;
     display: grid;

--- a/scripts/smoke-cockpit-web-live-loop.mjs
+++ b/scripts/smoke-cockpit-web-live-loop.mjs
@@ -26,16 +26,14 @@ const run = async () => {
         await waitForHttp(webUrl, "web cockpit")
 
         await ui(uiBrowser, session, ["open", webUrl, "1000"])
-        await ui(uiBrowser, session, ["wait-for", "text=No live sessions", "10000"])
-        await assertBrowserState(uiBrowser, session, {
+        await waitForBrowserState(uiBrowser, session, {
             mode: "Live HTTP",
             state: "No live sessions",
             detail: "no Every Code sessions",
         })
 
         await postJson(`${brokerUrl}/events`, { events: createLiveLoopEvents("Smoke broker live loop") })
-        await ui(uiBrowser, session, ["wait-for", "text=Smoke broker live loop", "10000"])
-        await assertBrowserState(uiBrowser, session, {
+        await waitForBrowserState(uiBrowser, session, {
             mode: "Live HTTP",
             state: "Stale event evidence retained",
             summary: "Smoke broker live loop",
@@ -45,6 +43,10 @@ const run = async () => {
 
         await clickFirstCommandButton(uiBrowser, session, "Trust")
         await waitForTrustedHost(brokerUrl, "smoke-host")
+        await waitForBrowserState(uiBrowser, session, {
+            trustRegistry: "Known hosts",
+            trustedHost: "smoke-host",
+        })
 
         await clickFirstCommandButton(uiBrowser, session, "Status")
         await waitForCommand(brokerUrl, "status_request")
@@ -55,8 +57,7 @@ const run = async () => {
 
         await stopProcess(broker)
         broker = null
-        await ui(uiBrowser, session, ["wait-for", "text=HTTP fallback", "10000"])
-        await assertBrowserState(uiBrowser, session, {
+        await waitForBrowserState(uiBrowser, session, {
             mode: "HTTP fallback",
             state: "Broker reconnecting",
             summary: "Smoke broker live loop",
@@ -67,8 +68,7 @@ const run = async () => {
         broker = startBroker(brokerPort)
         await waitForHttp(`${brokerUrl}/snapshot`, "restarted cockpit broker")
         await postJson(`${brokerUrl}/events`, { events: createLiveLoopEvents("Smoke broker reconnected") })
-        await ui(uiBrowser, session, ["wait-for", "text=Smoke broker reconnected", "10000"])
-        await assertBrowserState(uiBrowser, session, {
+        await waitForBrowserState(uiBrowser, session, {
             mode: "Live HTTP",
             summary: "Smoke broker reconnected",
             sessionId: "smoke-live-session",
@@ -254,12 +254,34 @@ const getJson = async (url) => {
 
 const ui = async (uiBrowser, session, args) => runCommand(uiBrowser, ["--session", session, ...args])
 
-const assertBrowserState = async (uiBrowser, session, expected) => {
+const waitForBrowserState = async (uiBrowser, session, expected) => {
+    const startedAt = Date.now()
+    let lastError = null
+
+    while (Date.now() - startedAt < 10000) {
+        try {
+            await assertBrowserState(uiBrowser, session, expected)
+            return
+        } catch (error) {
+            lastError = error
+        }
+        await delay(100)
+    }
+
+    throw lastError instanceof Error ? lastError : new Error("Timed out waiting for browser state")
+}
+
+const readBrowserState = async (uiBrowser, session) => {
     const raw = await ui(uiBrowser, session, [
         "eval",
-        "(() => ({ text: document.body.innerText, canScrollX: document.documentElement.scrollWidth > document.documentElement.clientWidth }))()",
+        "(() => ({ text: `${document.body.innerText}\n${document.body.textContent ?? ''}`, canScrollX: document.documentElement.scrollWidth > document.documentElement.clientWidth }))()",
     ])
-    const state = JSON.parse(raw)
+
+    return JSON.parse(raw)
+}
+
+const assertBrowserState = async (uiBrowser, session, expected) => {
+    const state = await readBrowserState(uiBrowser, session)
 
     for (const [label, value] of Object.entries(expected)) {
         if (!state.text.includes(value)) {


### PR DESCRIPTION
## Summary
- add `GET /trust` web client support and host-id revoke helper with response validation
- show a compact Known hosts trust registry list inside the Local trust panel
- keep active-session Trust/Revoke controls while allowing list-based revocation for trusted host records
- harden the web smoke to wait for live browser state and verify the known-host row after trusting the smoke host

## Validation
- `pnpm exec prettier --check apps/web/src/App.tsx apps/web/src/cockpitTrust.test.ts apps/web/src/cockpitTrust.ts apps/web/src/styles.css scripts/smoke-cockpit-web-live-loop.mjs`
- `pnpm lint:dry-run && pnpm --filter @code-everywhere/web test -- cockpitTrust.test.ts App.test.ts cockpitTransport.test.ts && pnpm smoke:cockpit:web`
- `pnpm lint:dry-run && pnpm validate && pnpm smoke:cockpit:web`
- contracts: 14 tests passed
- server: 52 tests passed
- web: 38 tests passed
- smoke: passed at `http://127.0.0.1:55647` using broker `http://127.0.0.1:55646`
- browser review at desktop `1024x768` and mobile `390x844`: no horizontal overflow; known-host row and Trust/Revoke buttons remained readable/stable
