### PR TITLE
Document Apple client shell decision

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,3 +13,9 @@ Start here when opening the repo.
 - [UI/UX Style](style/ui-ux.md) - cockpit design guardrails
 
 Decisions live in `docs/decisions/` once they become durable enough to record.
+
+Current durable decisions:
+
+- [0001 - Product Foundation](decisions/0001-product-foundation.md)
+- [0002 - Local Trust Persistence](decisions/0002-local-trust-persistence.md)
+- [0003 - Apple Client Shell](decisions/0003-apple-client-shell.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -81,10 +81,20 @@ revoking host records; it does not store route auth tokens in trust records.
 Expected client surfaces:
 
 - web cockpit for development and desktop use
-- iOS/iPadOS app or native wrapper for mobile operation
+- native Apple wrapper around the shared web cockpit for the first iOS,
+  iPadOS, and macOS checkpoint
+- later native SwiftUI surfaces where platform behavior justifies replacing a
+  shared cockpit view
 - macOS app or menu-bar companion when useful
 
 The first client should prove the structured cockpit, not every platform concern at once.
+
+The first Apple shell should be SwiftUI-based and host the existing cockpit in a
+native web view. Native code should initially own Keychain-backed device or
+broker credentials, APNs registration, notification action routing, deep links,
+and platform shell behavior. The React cockpit remains the source for session
+presentation and operator workflows until native-only screens have a specific
+reason to exist.
 
 ## Protocol Principles
 

--- a/docs/decisions/0003-apple-client-shell.md
+++ b/docs/decisions/0003-apple-client-shell.md
@@ -1,0 +1,63 @@
+# 0003: Apple Client Shell
+
+## Status
+
+Accepted
+
+## Context
+
+Code Everywhere is Apple-first, but the first working client is the React web
+cockpit. That cockpit now carries the product model for sessions, turns,
+pending work, commands, local broker state, and local trust records.
+
+The next Apple checkpoint needs native behavior for notifications, deep links,
+and device-held credentials without forking the cockpit UI or duplicating the
+session projection model before the product shape is stable.
+
+The realistic first-shell choices are:
+
+- PWA bridge: fastest to try, but weak for APNs, Keychain, notification actions,
+  and platform-correct deep-link behavior.
+- Full SwiftUI client: strongest native feel, but likely duplicates the React
+  cockpit and slows iteration before the session model is finished.
+- Native Apple wrapper around the shared web cockpit: preserves the current UI
+  investment while adding native integration points where the web cannot.
+
+## Decision
+
+The first Apple client checkpoint should be a native Apple wrapper around the
+shared web cockpit, not a PWA-only path and not a full native rewrite.
+
+The wrapper should be SwiftUI-based and host the cockpit in a native web view
+while keeping the broker/client protocol shared with the web app. Native code
+should own only Apple-specific concerns at first:
+
+- storing device-held secrets or broker credentials in Keychain
+- registering for APNs and routing notification actions
+- handling universal links or custom deep links into a session or pending item
+- exposing platform shell behavior such as windows, sidebars, menu commands, and
+  share/open affordances where useful
+- identifying the client device for future broker-mediated device trust
+
+The React cockpit remains the source for session presentation and operator
+workflows until there is a clear reason to replace individual surfaces with
+native SwiftUI views.
+
+The first implementation checkpoint should be a minimal `apps/apple` shell that
+can load the existing cockpit against a configured local broker, persist local
+connection credentials in Keychain, and prove one deep-link route into a session
+or pending item. APNs registration and notification actions can follow once the
+device identity path is in place.
+
+## Consequences
+
+- Product iteration remains centered on the shared cockpit instead of splitting
+  web and native UI logic immediately.
+- Apple-native work can start where it matters most: credentials, device
+  identity, notifications, and deep links.
+- The repo can add Apple build/test/release metadata only when the shell lands,
+  rather than adding inactive native infrastructure now.
+- A future full SwiftUI client remains possible if repeated wrapper limitations
+  appear, but that decision should be based on actual native integration needs.
+- A PWA can still be useful for fast web testing, but it is not the production
+  Apple-client strategy.

--- a/docs/every-code-integration.md
+++ b/docs/every-code-integration.md
@@ -79,6 +79,12 @@ to add are:
 - an operator/account identifier for clients that can enqueue commands
 - a device identifier for native clients and notification routing
 
+The first Apple-client shell should be a native wrapper around the shared web
+cockpit. It should use the same broker snapshot, command, and trust APIs as the
+web client while native code handles device-held secrets, notification
+registration, notification action routing, and deep links into session or
+pending-work state.
+
 ## What Not To Port
 
 Avoid carrying Discord-specific concepts into the core model:

--- a/docs/product-goals.md
+++ b/docs/product-goals.md
@@ -43,3 +43,5 @@ The UI should optimize for scanning and action, not spectacle.
 ## Apple Platform Expectations
 
 iOS, iPadOS, and macOS are first-class targets. A PWA can be useful for fast iteration, but the product should be ready for a native wrapper or native client because notifications, deep links, Keychain, and OS integration are part of the experience.
+
+The first Apple checkpoint is a native Apple wrapper around the shared web cockpit rather than a PWA-only path or full native rewrite. Native code should start by owning platform concerns such as Keychain storage, notification registration, notification actions, deep links, and device identity while the React cockpit remains the shared session and operator workflow surface.

--- a/docs/ui-reference.md
+++ b/docs/ui-reference.md
@@ -138,7 +138,10 @@ Use established UI primitives before custom design:
 - Radix UI for accessible primitives
 - Tailwind for styling
 - lucide-react for icons
-- Capacitor or SwiftUI when native Apple behavior matters
+- SwiftUI native wrapper for the first Apple shell, hosting the shared cockpit
+  while native code owns Keychain, notifications, deep links, and device identity
+- native SwiftUI views later when a specific Apple interaction cannot be served
+  well by the shared cockpit
 
 ## Review Rule
 


### PR DESCRIPTION
## Summary
- add ADR 0003 choosing a SwiftUI native wrapper around the shared web cockpit as the first Apple shell
- document the tradeoff against PWA-only and premature full SwiftUI rewrite paths
- update product, architecture, integration, UI reference, and docs index pages to point at the chosen path

## Validation
- `pnpm exec prettier --check docs/decisions/0003-apple-client-shell.md docs/product-goals.md docs/architecture.md docs/ui-reference.md docs/every-code-integration.md docs/README.md`
- `pnpm lint:dry-run && pnpm validate`
- contracts: 14 tests passed
- server: 52 tests passed
- web: 38 tests passed
