### PR TITLE
Add Apple wrapper scaffold

### DIFF
--- a/.github/github-repo-workflow.json
+++ b/.github/github-repo-workflow.json
@@ -49,7 +49,7 @@
             "product decisions change"
         ]
     },
-    "importantWorkflows": ["CI", "CodeQL"],
+    "importantWorkflows": ["CI", "CodeQL", "Apple"],
     "qaLabels": [],
     "deployLabels": [],
     "healthUrls": [],

--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -1,0 +1,37 @@
+---
+name: Apple
+
+"on":
+    workflow_dispatch:
+    pull_request:
+        paths:
+            - ".github/workflows/apple.yml"
+            - "apps/apple/**"
+            - "package.json"
+            - "README.md"
+            - "docs/**"
+    push:
+        branches:
+            - main
+        paths:
+            - ".github/workflows/apple.yml"
+            - "apps/apple/**"
+            - "package.json"
+            - "README.md"
+            - "docs/**"
+
+permissions:
+    contents: read
+
+jobs:
+    swift-package:
+        runs-on: macos-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Swift build
+              run: swift build --package-path apps/apple
+
+            - name: Swift test
+              run: swift test --package-path apps/apple

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ dist/
 coverage/
 .turbo/
 .vite/
+.build/
+.swiftpm/
+.code/
 .code-everywhere/
 .env
 .env.*

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Workspace packages:
   projection, and local HTTP transport boundary.
 - `apps/web`: React/Vite cockpit UI for projected fake data or local HTTP
   snapshots and command dispatch.
+- `apps/apple`: Swift package scaffold for the native Apple wrapper around the
+  shared cockpit, including connection settings, deep-link parsing, Keychain
+  token storage, and a SwiftUI/WebKit shell.
 
 Useful entry points:
 
@@ -58,6 +61,18 @@ positive millisecond interval.
 The local server binds to `127.0.0.1:4789` by default. Override it with
 `CODE_EVERYWHERE_HOST`, `CODE_EVERYWHERE_PORT`, `--host`, or `--port` when a
 different local endpoint is needed.
+
+The Apple wrapper scaffold is a Swift package, not a signed app target yet. Use
+the local Swift toolchain to build or test its native support code:
+
+```sh
+pnpm apple:build
+pnpm apple:test
+```
+
+The scaffold hosts the shared cockpit in a native web view and keeps native code
+focused on platform boundaries: Keychain-backed broker tokens, future device
+identity, and deep-link routing into session or pending-work state.
 
 ## References
 

--- a/apps/apple/Package.swift
+++ b/apps/apple/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "CodeEverywhereApple",
+    platforms: [
+        .iOS(.v17),
+        .macOS(.v14),
+    ],
+    products: [
+        .library(name: "CodeEverywhereAppleCore", targets: ["CodeEverywhereAppleCore"]),
+        .library(name: "CodeEverywhereAppleUI", targets: ["CodeEverywhereAppleUI"]),
+    ],
+    targets: [
+        .target(name: "CodeEverywhereAppleCore"),
+        .target(name: "CodeEverywhereAppleUI", dependencies: ["CodeEverywhereAppleCore"]),
+        .testTarget(name: "CodeEverywhereAppleCoreTests", dependencies: ["CodeEverywhereAppleCore"]),
+    ]
+)

--- a/apps/apple/Sources/CodeEverywhereAppleCore/CockpitConnectionSettings.swift
+++ b/apps/apple/Sources/CodeEverywhereAppleCore/CockpitConnectionSettings.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+public struct CockpitConnectionSettings: Equatable, Sendable {
+    public var cockpitURL: URL
+    public var brokerURL: URL?
+    public var brokerAuthToken: String?
+
+    public init(cockpitURL: URL, brokerURL: URL? = nil, brokerAuthToken: String? = nil) {
+        self.cockpitURL = cockpitURL
+        self.brokerURL = brokerURL
+        self.brokerAuthToken = brokerAuthToken?.nilIfBlank
+    }
+}
+
+public struct CockpitConnectionSettingsStore {
+    private let defaults: UserDefaults
+    private let secrets: SecretStore
+    private let cockpitURLKey: String
+    private let brokerURLKey: String
+    private let authTokenKey: String
+
+    public init(
+        defaults: UserDefaults = .standard,
+        secrets: SecretStore,
+        namespace: String = "CodeEverywhere"
+    ) {
+        self.defaults = defaults
+        self.secrets = secrets
+        self.cockpitURLKey = "\(namespace).cockpitURL"
+        self.brokerURLKey = "\(namespace).brokerURL"
+        self.authTokenKey = "\(namespace).brokerAuthToken"
+    }
+
+    public func load() throws -> CockpitConnectionSettings? {
+        guard let cockpitURL = loadURL(forKey: cockpitURLKey) else {
+            return nil
+        }
+
+        return CockpitConnectionSettings(
+            cockpitURL: cockpitURL,
+            brokerURL: loadURL(forKey: brokerURLKey),
+            brokerAuthToken: try secrets.readSecret(account: authTokenKey)
+        )
+    }
+
+    public func save(_ settings: CockpitConnectionSettings) throws {
+        defaults.set(settings.cockpitURL.absoluteString, forKey: cockpitURLKey)
+        if let brokerURL = settings.brokerURL {
+            defaults.set(brokerURL.absoluteString, forKey: brokerURLKey)
+        } else {
+            defaults.removeObject(forKey: brokerURLKey)
+        }
+
+        if let token = settings.brokerAuthToken?.nilIfBlank {
+            try secrets.saveSecret(token, account: authTokenKey)
+        } else {
+            try secrets.deleteSecret(account: authTokenKey)
+        }
+    }
+
+    public func clear() throws {
+        defaults.removeObject(forKey: cockpitURLKey)
+        defaults.removeObject(forKey: brokerURLKey)
+        try secrets.deleteSecret(account: authTokenKey)
+    }
+
+    private func loadURL(forKey key: String) -> URL? {
+        guard let rawValue = defaults.string(forKey: key)?.nilIfBlank else {
+            return nil
+        }
+
+        return URL(string: rawValue)
+    }
+}
+
+extension String {
+    var nilIfBlank: String? {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/apps/apple/Sources/CodeEverywhereAppleCore/CockpitDeepLink.swift
+++ b/apps/apple/Sources/CodeEverywhereAppleCore/CockpitDeepLink.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+public enum CockpitDeepLinkRoute: Equatable, Sendable {
+    case session(sessionId: String, pendingItemId: String?)
+    case pendingItem(pendingItemId: String, sessionId: String?)
+}
+
+public struct CockpitDeepLinkParser: Sendable {
+    public init() {}
+
+    public func parse(_ url: URL) -> CockpitDeepLinkRoute? {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+
+        let pathParts = makePathParts(url: url)
+        let query = makeQueryMap(components: components)
+
+        if pathParts.first == "session", let sessionId = pathParts.dropFirst().first?.nilIfBlank {
+            return .session(sessionId: sessionId, pendingItemId: query["pending"]?.nilIfBlank)
+        }
+
+        if pathParts.first == "pending", let pendingItemId = pathParts.dropFirst().first?.nilIfBlank {
+            return .pendingItem(pendingItemId: pendingItemId, sessionId: query["session"]?.nilIfBlank)
+        }
+
+        return nil
+    }
+
+    public func webFragment(for route: CockpitDeepLinkRoute) -> String {
+        switch route {
+        case let .session(sessionId, pendingItemId):
+            return makeFragment(path: ["session", sessionId], query: ["pending": pendingItemId])
+        case let .pendingItem(pendingItemId, sessionId):
+            return makeFragment(path: ["pending", pendingItemId], query: ["session": sessionId])
+        }
+    }
+
+    private func makePathParts(url: URL) -> [String] {
+        var parts: [String] = []
+        if url.scheme == "code-everywhere", let host = url.host(percentEncoded: false), host != "" {
+            parts.append(host)
+        }
+
+        parts.append(contentsOf: url.pathComponents.filter { $0 != "/" })
+        return parts
+    }
+
+    private func makeQueryMap(components: URLComponents) -> [String: String] {
+        Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).compactMap { item in
+            guard let value = item.value else {
+                return nil
+            }
+            return (item.name, value)
+        })
+    }
+
+    private func makeFragment(path: [String], query: [String: String?]) -> String {
+        var components = URLComponents()
+        components.path = "/" + path.map(percentEncodePathPart).joined(separator: "/")
+        let queryItems: [URLQueryItem] = query.compactMap { name, value in
+            guard let value = value?.nilIfBlank else {
+                return nil
+            }
+            return URLQueryItem(name: name, value: value)
+        }
+        components.queryItems = queryItems.isEmpty ? nil : queryItems
+        return components.string ?? components.path
+    }
+
+    private func percentEncodePathPart(_ value: String) -> String {
+        value.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? value
+    }
+}

--- a/apps/apple/Sources/CodeEverywhereAppleCore/SecretStore.swift
+++ b/apps/apple/Sources/CodeEverywhereAppleCore/SecretStore.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Security
+
+public protocol SecretStore: Sendable {
+    func readSecret(account: String) throws -> String?
+    func saveSecret(_ secret: String, account: String) throws
+    func deleteSecret(account: String) throws
+}
+
+public enum SecretStoreError: Error, Equatable {
+    case unexpectedData
+    case keychainStatus(OSStatus)
+}
+
+public final class KeychainSecretStore: SecretStore, @unchecked Sendable {
+    private let service: String
+
+    public init(service: String = "CodeEverywhere") {
+        self.service = service
+    }
+
+    public func readSecret(account: String) throws -> String? {
+        var query = baseQuery(account: account)
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        query[kSecReturnData as String] = true
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        if status == errSecItemNotFound {
+            return nil
+        }
+        guard status == errSecSuccess else {
+            throw SecretStoreError.keychainStatus(status)
+        }
+        guard let data = item as? Data, let secret = String(data: data, encoding: .utf8) else {
+            throw SecretStoreError.unexpectedData
+        }
+        return secret
+    }
+
+    public func saveSecret(_ secret: String, account: String) throws {
+        try deleteSecret(account: account)
+
+        var query = baseQuery(account: account)
+        query[kSecValueData as String] = Data(secret.utf8)
+
+        let status = SecItemAdd(query as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw SecretStoreError.keychainStatus(status)
+        }
+    }
+
+    public func deleteSecret(account: String) throws {
+        let status = SecItemDelete(baseQuery(account: account) as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw SecretStoreError.keychainStatus(status)
+        }
+    }
+
+    private func baseQuery(account: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+    }
+}
+
+public final class InMemorySecretStore: SecretStore, @unchecked Sendable {
+    private var secrets: [String: String] = [:]
+    private let lock = NSLock()
+
+    public init() {}
+
+    public func readSecret(account: String) -> String? {
+        lock.withLock {
+            secrets[account]
+        }
+    }
+
+    public func saveSecret(_ secret: String, account: String) {
+        lock.withLock {
+            secrets[account] = secret
+        }
+    }
+
+    public func deleteSecret(account: String) {
+        lock.withLock {
+            _ = secrets.removeValue(forKey: account)
+        }
+    }
+}

--- a/apps/apple/Sources/CodeEverywhereAppleUI/CockpitWebShell.swift
+++ b/apps/apple/Sources/CodeEverywhereAppleUI/CockpitWebShell.swift
@@ -1,0 +1,80 @@
+import CodeEverywhereAppleCore
+import SwiftUI
+import WebKit
+
+public struct CockpitWebShell: View {
+    private let settings: CockpitConnectionSettings
+    private let deepLinkRoute: CockpitDeepLinkRoute?
+
+    public init(settings: CockpitConnectionSettings, deepLinkRoute: CockpitDeepLinkRoute? = nil) {
+        self.settings = settings
+        self.deepLinkRoute = deepLinkRoute
+    }
+
+    public var body: some View {
+        CockpitWebView(url: shellURL)
+            .navigationTitle("Code Everywhere")
+    }
+
+    private var shellURL: URL {
+        guard let deepLinkRoute else {
+            return settings.cockpitURL
+        }
+
+        var components = URLComponents(url: settings.cockpitURL, resolvingAgainstBaseURL: false)
+        components?.fragment = CockpitDeepLinkParser().webFragment(for: deepLinkRoute)
+        return components?.url ?? settings.cockpitURL
+    }
+}
+
+#if os(macOS)
+public struct CockpitWebView: NSViewRepresentable {
+    private let url: URL
+
+    public init(url: URL) {
+        self.url = url
+    }
+
+    public func makeNSView(context _: Context) -> WKWebView {
+        makeWebView(url: url)
+    }
+
+    public func updateNSView(_ webView: WKWebView, context _: Context) {
+        loadIfNeeded(webView, url: url)
+    }
+}
+#elseif os(iOS)
+public struct CockpitWebView: UIViewRepresentable {
+    private let url: URL
+
+    public init(url: URL) {
+        self.url = url
+    }
+
+    public func makeUIView(context _: Context) -> WKWebView {
+        makeWebView(url: url)
+    }
+
+    public func updateUIView(_ webView: WKWebView, context _: Context) {
+        loadIfNeeded(webView, url: url)
+    }
+}
+#endif
+
+@MainActor
+private func makeWebView(url: URL) -> WKWebView {
+    let configuration = WKWebViewConfiguration()
+    configuration.defaultWebpagePreferences.allowsContentJavaScript = true
+    let webView = WKWebView(frame: .zero, configuration: configuration)
+    webView.load(URLRequest(url: url))
+    return webView
+}
+
+@MainActor
+private func loadIfNeeded(_ webView: WKWebView, url: URL) {
+    guard webView.url != url else {
+        return
+    }
+
+    webView.load(URLRequest(url: url))
+}

--- a/apps/apple/Tests/CodeEverywhereAppleCoreTests/CockpitConnectionSettingsTests.swift
+++ b/apps/apple/Tests/CodeEverywhereAppleCoreTests/CockpitConnectionSettingsTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+
+@testable import CodeEverywhereAppleCore
+
+@Suite("Cockpit connection settings")
+struct CockpitConnectionSettingsTests {
+    @Test("persists public URLs separately from secret broker token")
+    func persistsConnectionSettings() throws {
+        let defaults = makeDefaults()
+        let secrets = InMemorySecretStore()
+        let store = CockpitConnectionSettingsStore(defaults: defaults, secrets: secrets, namespace: "test")
+        let settings = CockpitConnectionSettings(
+            cockpitURL: try #require(URL(string: "http://127.0.0.1:5173")),
+            brokerURL: try #require(URL(string: "http://127.0.0.1:4789")),
+            brokerAuthToken: " token-value "
+        )
+
+        try store.save(settings)
+
+        #expect(defaults.string(forKey: "test.cockpitURL") == "http://127.0.0.1:5173")
+        #expect(defaults.string(forKey: "test.brokerURL") == "http://127.0.0.1:4789")
+        #expect(defaults.string(forKey: "test.brokerAuthToken") == nil)
+        #expect(try store.load() == CockpitConnectionSettings(
+            cockpitURL: try #require(URL(string: "http://127.0.0.1:5173")),
+            brokerURL: try #require(URL(string: "http://127.0.0.1:4789")),
+            brokerAuthToken: "token-value"
+        ))
+    }
+
+    @Test("clears stored URLs and token")
+    func clearsConnectionSettings() throws {
+        let defaults = makeDefaults()
+        let store = CockpitConnectionSettingsStore(defaults: defaults, secrets: InMemorySecretStore(), namespace: "clear")
+        try store.save(CockpitConnectionSettings(cockpitURL: try #require(URL(string: "http://127.0.0.1:5173")), brokerAuthToken: "secret"))
+
+        try store.clear()
+
+        #expect(try store.load() == nil)
+    }
+
+    private func makeDefaults() -> UserDefaults {
+        let suiteName = "CodeEverywhereAppleTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}

--- a/apps/apple/Tests/CodeEverywhereAppleCoreTests/CockpitDeepLinkTests.swift
+++ b/apps/apple/Tests/CodeEverywhereAppleCoreTests/CockpitDeepLinkTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Testing
+
+@testable import CodeEverywhereAppleCore
+
+@Suite("Cockpit deep links")
+struct CockpitDeepLinkTests {
+    private let parser = CockpitDeepLinkParser()
+
+    @Test("parses session deep links")
+    func parsesSessionLinks() throws {
+        let route = parser.parse(try #require(URL(string: "code-everywhere://session/session-123?pending=approval-9")))
+
+        #expect(route == .session(sessionId: "session-123", pendingItemId: "approval-9"))
+    }
+
+    @Test("parses pending-item deep links")
+    func parsesPendingItemLinks() throws {
+        let route = parser.parse(try #require(URL(string: "code-everywhere://pending/input-7?session=session-123")))
+
+        #expect(route == .pendingItem(pendingItemId: "input-7", sessionId: "session-123"))
+    }
+
+    @Test("rejects links without a supported route")
+    func rejectsUnsupportedLinks() throws {
+        #expect(parser.parse(try #require(URL(string: "code-everywhere://settings"))) == nil)
+    }
+
+    @Test("creates web fragments for shared cockpit routing")
+    func createsWebFragments() {
+        #expect(parser.webFragment(for: .session(sessionId: "session-123", pendingItemId: "approval-9")) == "/session/session-123?pending=approval-9")
+        #expect(parser.webFragment(for: .pendingItem(pendingItemId: "input-7", sessionId: nil)) == "/pending/input-7")
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -96,6 +96,11 @@ and platform shell behavior. The React cockpit remains the source for session
 presentation and operator workflows until native-only screens have a specific
 reason to exist.
 
+The first scaffold lives in `apps/apple` as a Swift package. It is not a signed
+Xcode app target yet; it establishes the shared cockpit web-view shell,
+connection settings, Keychain-backed token storage, and deep-link parsing that a
+future app target can consume.
+
 ## Protocol Principles
 
 - Use explicit event types and command types.

--- a/docs/repo-settings.md
+++ b/docs/repo-settings.md
@@ -28,6 +28,7 @@ The repo starts with validation CI only:
 - type check
 - tests
 - CodeQL
+- Apple Swift package build/test for `apps/apple`
 
 CD is intentionally deferred until the first deploy target is clear. Likely future targets:
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "description": "A structured Apple-first control surface for Every Code sessions.",
     "packageManager": "pnpm@10.10.0",
     "scripts": {
+        "apple:build": "swift build --package-path apps/apple",
+        "apple:test": "swift test --package-path apps/apple",
         "cockpit:server": "pnpm --filter @code-everywhere/server start",
         "format": "prettier --write .",
         "format:check": "prettier --check .",


### PR DESCRIPTION
## Summary
- add `apps/apple` Swift package scaffold with core and SwiftUI/WebKit wrapper targets
- add connection settings, Keychain-backed token storage abstraction, and deep-link parsing support with Swift tests
- add local `pnpm apple:build` / `pnpm apple:test` commands and an Apple GitHub Actions workflow on macOS
- document the scaffold in README, architecture, repo settings, and workflow metadata

## Validation
- `pnpm exec prettier --check .github/workflows/apple.yml .github/github-repo-workflow.json docs/repo-settings.md package.json README.md docs/architecture.md`
- `actionlint .github/workflows/apple.yml`
- `pnpm apple:build && pnpm apple:test`
- `pnpm lint:dry-run && pnpm validate`
- Swift: 6 tests in 2 suites passed
- contracts: 14 tests passed
- server: 52 tests passed
- web: 38 tests passed
