### PR TITLE
Fix trust registry refresh ordering

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -34,7 +34,7 @@ import {
     TerminalSquare,
     X,
 } from "lucide-react"
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 
 import { canPostCockpitCommand, postCockpitCommand } from "./cockpitCommands"
 import {
@@ -195,6 +195,7 @@ export const App = () => {
         status: "unavailable",
         message: "Connect to a live broker to review local trust records.",
     })
+    const trustRegistryRequestId = useRef(0)
     const fallbackSession = cockpit.sessions[0]
     const activeSession =
         fallbackSession === undefined
@@ -233,6 +234,7 @@ export const App = () => {
 
         let isActive = true
         const transportUrl = cockpitView.transport.url
+        const requestId = (trustRegistryRequestId.current += 1)
         setTrustRegistry((current) => ({
             snapshot: current.snapshot,
             status: current.snapshot === null ? "loading" : "ready",
@@ -240,13 +242,13 @@ export const App = () => {
         }))
         void fetchLocalTrustRegistry(transportUrl)
             .then((snapshot) => {
-                if (!isActive) {
+                if (!isActive || requestId !== trustRegistryRequestId.current) {
                     return
                 }
                 setTrustRegistry({ snapshot, status: "ready", message: "Local trust records loaded." })
             })
             .catch((error: unknown) => {
-                if (!isActive) {
+                if (!isActive || requestId !== trustRegistryRequestId.current) {
                     return
                 }
                 setTrustRegistry((current) => ({
@@ -318,6 +320,7 @@ export const App = () => {
                     session.hostId === undefined
                         ? undefined
                         : snapshot.hosts.find((candidate) => candidate.hostId === session.hostId)
+                trustRegistryRequestId.current += 1
                 setTrustRegistry({ snapshot, status: "ready", message: "Local trust records loaded." })
                 setTrustLog(`${label} saved for ${session.hostLabel}; ${host?.status ?? "host record updated"}`)
             })
@@ -336,6 +339,7 @@ export const App = () => {
         void postRevokedHostId(cockpitView.transport.url, host.hostId)
             .then((snapshot) => {
                 const updatedHost = snapshot.hosts.find((candidate) => candidate.hostId === host.hostId)
+                trustRegistryRequestId.current += 1
                 setTrustRegistry({ snapshot, status: "ready", message: "Local trust records loaded." })
                 setTrustLog(`Revoke host saved for ${host.label}; ${updatedHost?.status ?? "host record updated"}`)
             })
@@ -937,6 +941,7 @@ const TrustRegistryList = ({
                 <span>Known hosts</span>
                 <strong>{hosts.length}</strong>
             </div>
+            {registry.status === "error" ? <p className="trust-registry-error">{registry.message}</p> : null}
             {sortedHosts.length === 0 ? (
                 <p className="trust-registry-empty">{registry.message}</p>
             ) : (

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1013,10 +1013,15 @@ input:focus {
     font-size: 11px;
 }
 
-.trust-registry-empty {
+.trust-registry-empty,
+.trust-registry-error {
     color: var(--fg-3);
     font-size: 12px;
     white-space: normal;
+}
+
+.trust-registry-error {
+    color: #991b1b;
 }
 
 .trust-record-list {

--- a/scripts/smoke-cockpit-web-live-loop.mjs
+++ b/scripts/smoke-cockpit-web-live-loop.mjs
@@ -41,6 +41,7 @@ const run = async () => {
             detail: "Broker/web smoke step complete.",
         })
 
+        await clickSessionButton(uiBrowser, session, "smoke-live-session")
         await clickFirstCommandButton(uiBrowser, session, "Trust")
         await waitForTrustedHost(brokerUrl, "smoke-host")
         await waitForBrowserState(uiBrowser, session, {
@@ -297,6 +298,13 @@ const clickFirstCommandButton = async (uiBrowser, session, label) => {
     await ui(uiBrowser, session, [
         "eval",
         `(() => { const label = ${JSON.stringify(label)}; const button = Array.from(document.querySelectorAll('button')).find((candidate) => candidate.innerText.trim() === label); if (!button) throw new Error(label + ' button not found'); button.click(); return true; })()`,
+    ])
+}
+
+const clickSessionButton = async (uiBrowser, session, sessionId) => {
+    await ui(uiBrowser, session, [
+        "eval",
+        `(() => { const sessionId = ${JSON.stringify(sessionId)}; const label = Array.from(document.querySelectorAll('.session-id')).find((candidate) => candidate.textContent?.trim() === sessionId); const button = label?.closest('button'); if (!button) throw new Error(sessionId + ' session button not found'); button.click(); return true; })()`,
     ])
 }
 


### PR DESCRIPTION
## Summary
- prevent older `GET /trust` refreshes from overwriting newer trust/revoke snapshots
- show trust refresh errors even when cached known-host rows are still available
- explicitly select the smoke live session before clicking Trust in the web smoke

## Validation
- `pnpm exec prettier --check apps/web/src/App.tsx apps/web/src/styles.css scripts/smoke-cockpit-web-live-loop.mjs`
- `pnpm lint:dry-run && pnpm --filter @code-everywhere/web test -- App.test.ts cockpitTrust.test.ts cockpitTransport.test.ts && pnpm smoke:cockpit:web`
- `pnpm lint:dry-run && pnpm validate && pnpm smoke:cockpit:web`
- contracts: 14 tests passed
- server: 52 tests passed
- web: 38 tests passed
- smoke: passed at `http://127.0.0.1:54070` using broker `http://127.0.0.1:54069`
