### PR TITLE
Add Apple app target scaffold

### DIFF
--- a/.github/github-repo-workflow.json
+++ b/.github/github-repo-workflow.json
@@ -29,6 +29,7 @@
             "default": "pnpm typecheck"
         },
         "build": {
+            "apple": "pnpm apple:build && pnpm apple:test && pnpm apple:app:build",
             "validate": "pnpm validate",
             "web": "pnpm --filter @code-everywhere/web build",
             "server": "pnpm --filter @code-everywhere/server build",

--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -30,8 +30,21 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v4
 
+            - name: Install XcodeGen
+              run: brew install xcodegen
+
             - name: Swift build
               run: swift build --package-path apps/apple
 
             - name: Swift test
               run: swift test --package-path apps/apple
+
+            - name: iOS app build
+              run: |
+                  xcodegen generate --spec apps/apple/project.yml
+                  xcodebuild \
+                      -project apps/apple/CodeEverywhereApple.xcodeproj \
+                      -scheme CodeEverywhere \
+                      -destination 'generic/platform=iOS Simulator' \
+                      CODE_SIGNING_ALLOWED=NO \
+                      build

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ coverage/
 .vite/
 .build/
 .swiftpm/
+apps/apple/CodeEverywhereApple.xcodeproj/
 .code/
 .code-everywhere/
 .env

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Workspace packages:
   projection, and local HTTP transport boundary.
 - `apps/web`: React/Vite cockpit UI for projected fake data or local HTTP
   snapshots and command dispatch.
-- `apps/apple`: Swift package scaffold for the native Apple wrapper around the
-  shared cockpit, including connection settings, deep-link parsing, Keychain
-  token storage, and a SwiftUI/WebKit shell.
+- `apps/apple`: native Apple wrapper around the shared cockpit, including a
+  Swift package for connection settings, deep-link parsing, Keychain token
+  storage, a SwiftUI/WebKit shell, and a generated iOS/iPadOS app target.
 
 Useful entry points:
 
@@ -62,17 +62,21 @@ The local server binds to `127.0.0.1:4789` by default. Override it with
 `CODE_EVERYWHERE_HOST`, `CODE_EVERYWHERE_PORT`, `--host`, or `--port` when a
 different local endpoint is needed.
 
-The Apple wrapper scaffold is a Swift package, not a signed app target yet. Use
-the local Swift toolchain to build or test its native support code:
+The Apple wrapper keeps generated Xcode project files out of source control.
+Use XcodeGen when you need the local project, and use the Swift toolchain for
+native support code:
 
 ```sh
+pnpm apple:generate
 pnpm apple:build
 pnpm apple:test
+pnpm apple:app:build
 ```
 
-The scaffold hosts the shared cockpit in a native web view and keeps native code
-focused on platform boundaries: Keychain-backed broker tokens, future device
-identity, and deep-link routing into session or pending-work state.
+The iOS/iPadOS app target builds for the simulator with signing disabled. It
+hosts the shared cockpit in a native web view and keeps native code focused on
+platform boundaries: Keychain-backed broker tokens, future device identity, and
+deep-link routing into session or pending-work state.
 
 ## References
 

--- a/apps/apple/App/CodeEverywhereApp.swift
+++ b/apps/apple/App/CodeEverywhereApp.swift
@@ -1,0 +1,26 @@
+import CodeEverywhereAppleCore
+import CodeEverywhereAppleUI
+import SwiftUI
+
+@main
+struct CodeEverywhereApp: App {
+    @State private var deepLinkRoute: CockpitDeepLinkRoute?
+
+    private let deepLinkParser = CockpitDeepLinkParser()
+    private let settings = CockpitConnectionSettings(
+        cockpitURL: URL(string: "http://127.0.0.1:5173")!,
+        brokerURL: URL(string: "http://127.0.0.1:3000")!
+    )
+
+    var body: some Scene {
+        WindowGroup {
+            NavigationStack {
+                CockpitWebShell(settings: settings, deepLinkRoute: deepLinkRoute)
+                    .ignoresSafeArea(edges: .bottom)
+            }
+            .onOpenURL { url in
+                deepLinkRoute = deepLinkParser.parse(url)
+            }
+        }
+    }
+}

--- a/apps/apple/App/Info.plist
+++ b/apps/apple/App/Info.plist
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Code Everywhere</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.1</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>Code Everywhere</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>code-everywhere</string>
+			</array>
+		</dict>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+</dict>
+</plist>

--- a/apps/apple/Tests/CodeEverywhereAppleCoreTests/CockpitConnectionSettingsTests.swift
+++ b/apps/apple/Tests/CodeEverywhereAppleCoreTests/CockpitConnectionSettingsTests.swift
@@ -11,8 +11,8 @@ struct CockpitConnectionSettingsTests {
         let secrets = InMemorySecretStore()
         let store = CockpitConnectionSettingsStore(defaults: defaults, secrets: secrets, namespace: "test")
         let settings = CockpitConnectionSettings(
-            cockpitURL: try #require(URL(string: "http://127.0.0.1:5173")),
-            brokerURL: try #require(URL(string: "http://127.0.0.1:4789")),
+            cockpitURL: URL(string: "http://127.0.0.1:5173")!,
+            brokerURL: URL(string: "http://127.0.0.1:4789")!,
             brokerAuthToken: " token-value "
         )
 
@@ -22,8 +22,8 @@ struct CockpitConnectionSettingsTests {
         #expect(defaults.string(forKey: "test.brokerURL") == "http://127.0.0.1:4789")
         #expect(defaults.string(forKey: "test.brokerAuthToken") == nil)
         #expect(try store.load() == CockpitConnectionSettings(
-            cockpitURL: try #require(URL(string: "http://127.0.0.1:5173")),
-            brokerURL: try #require(URL(string: "http://127.0.0.1:4789")),
+            cockpitURL: URL(string: "http://127.0.0.1:5173")!,
+            brokerURL: URL(string: "http://127.0.0.1:4789")!,
             brokerAuthToken: "token-value"
         ))
     }
@@ -32,7 +32,10 @@ struct CockpitConnectionSettingsTests {
     func clearsConnectionSettings() throws {
         let defaults = makeDefaults()
         let store = CockpitConnectionSettingsStore(defaults: defaults, secrets: InMemorySecretStore(), namespace: "clear")
-        try store.save(CockpitConnectionSettings(cockpitURL: try #require(URL(string: "http://127.0.0.1:5173")), brokerAuthToken: "secret"))
+        try store.save(CockpitConnectionSettings(
+            cockpitURL: URL(string: "http://127.0.0.1:5173")!,
+            brokerAuthToken: "secret"
+        ))
 
         try store.clear()
 

--- a/apps/apple/project.yml
+++ b/apps/apple/project.yml
@@ -1,0 +1,42 @@
+---
+name: CodeEverywhereApple
+options:
+    bundleIdPrefix: com.codeeverywhere
+    deploymentTarget:
+        iOS: "17.0"
+packages:
+    CodeEverywhereApple:
+        path: .
+targets:
+    CodeEverywhere:
+        type: application
+        platform: iOS
+        deploymentTarget: "17.0"
+        sources:
+            - path: App
+        dependencies:
+            - package: CodeEverywhereApple
+              product: CodeEverywhereAppleUI
+        settings:
+            base:
+                CODE_SIGNING_ALLOWED: "NO"
+                CODE_SIGN_STYLE: Manual
+                DEVELOPMENT_TEAM: ""
+                PRODUCT_BUNDLE_IDENTIFIER: com.codeeverywhere.app
+                SWIFT_VERSION: "6.0"
+                TARGETED_DEVICE_FAMILY: "1,2"
+        info:
+            path: App/Info.plist
+            properties:
+                CFBundleDisplayName: Code Everywhere
+                CFBundleShortVersionString: "0.1"
+                CFBundleVersion: "1"
+                CFBundleURLTypes:
+                    - CFBundleURLName: Code Everywhere
+                      CFBundleURLSchemes:
+                          - code-everywhere
+                LSRequiresIPhoneOS: true
+                UIApplicationSceneManifest:
+                    UIApplicationSupportsMultipleScenes: true
+                UIApplicationSupportsIndirectInputEvents: true
+                UILaunchScreen: {}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -96,10 +96,13 @@ and platform shell behavior. The React cockpit remains the source for session
 presentation and operator workflows until native-only screens have a specific
 reason to exist.
 
-The first scaffold lives in `apps/apple` as a Swift package. It is not a signed
-Xcode app target yet; it establishes the shared cockpit web-view shell,
-connection settings, Keychain-backed token storage, and deep-link parsing that a
-future app target can consume.
+The first scaffold lives in `apps/apple` as a Swift package plus a generated
+Xcode app target. The committed `project.yml` is the source of truth for the
+iOS/iPadOS app project; `CodeEverywhereApple.xcodeproj` is regenerated locally
+or in CI and is not committed. The app target is intentionally unsigned for now
+and simulator-buildable with `CODE_SIGNING_ALLOWED=NO`. It launches the shared
+cockpit web-view shell and consumes the package-owned connection settings,
+Keychain-backed token storage, and deep-link parsing.
 
 ## Protocol Principles
 

--- a/docs/repo-settings.md
+++ b/docs/repo-settings.md
@@ -29,6 +29,7 @@ The repo starts with validation CI only:
 - tests
 - CodeQL
 - Apple Swift package build/test for `apps/apple`
+- Apple generated iOS/iPadOS app target build for the simulator
 
 CD is intentionally deferred until the first deploy target is clear. Likely future targets:
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "description": "A structured Apple-first control surface for Every Code sessions.",
     "packageManager": "pnpm@10.10.0",
     "scripts": {
+        "apple:app:build": "pnpm apple:generate && xcodebuild -project apps/apple/CodeEverywhereApple.xcodeproj -scheme CodeEverywhere -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build",
         "apple:build": "swift build --package-path apps/apple",
+        "apple:generate": "xcodegen generate --spec apps/apple/project.yml",
         "apple:test": "swift test --package-path apps/apple",
         "cockpit:server": "pnpm --filter @code-everywhere/server start",
         "format": "prettier --write .",


### PR DESCRIPTION
## Summary
- add an XcodeGen-backed iOS/iPadOS app target for the Apple wrapper without committing generated Xcode project files or signing credentials
- wire the app entry point to CodeEverywhereAppleUI so it launches the shared cockpit shell and handles code-everywhere deep links
- add local scripts, Apple workflow coverage, and docs/metadata for generating and simulator-building the app target

## Validation
- pnpm apple:build
- pnpm apple:test
- pnpm apple:app:build
- concrete simulator proof: built for iPhone 17 / iOS 26.4, installed CodeEverywhere.app, launched com.codeeverywhere.app
- actionlint .github/workflows/apple.yml
- pnpm lint:dry-run
- pnpm validate
- pnpm smoke:cockpit:web