### PR TITLE
Add Apple notification route scaffolding

### DIFF
--- a/apps/apple/App/CodeEverywhereApp.swift
+++ b/apps/apple/App/CodeEverywhereApp.swift
@@ -7,6 +7,7 @@ struct CodeEverywhereApp: App {
     @State private var deepLinkRoute: CockpitDeepLinkRoute?
 
     private let deepLinkParser = CockpitDeepLinkParser()
+    private let notificationRouter = CockpitNotificationRouter()
     private let settings = CockpitConnectionSettings(
         cockpitURL: URL(string: "http://127.0.0.1:5173")!,
         brokerURL: URL(string: "http://127.0.0.1:3000")!
@@ -19,7 +20,7 @@ struct CodeEverywhereApp: App {
                     .ignoresSafeArea(edges: .bottom)
             }
             .onOpenURL { url in
-                deepLinkRoute = deepLinkParser.parse(url)
+                deepLinkRoute = notificationRouter.route(from: url)?.deepLinkRoute ?? deepLinkParser.parse(url)
             }
         }
     }

--- a/apps/apple/Sources/CodeEverywhereAppleCore/CockpitNotificationRoute.swift
+++ b/apps/apple/Sources/CodeEverywhereAppleCore/CockpitNotificationRoute.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+public enum CockpitNotificationRoute: Equatable, Sendable {
+    case session(sessionId: String)
+    case pendingItem(pendingItemId: String, sessionId: String?)
+
+    public init?(deepLinkRoute: CockpitDeepLinkRoute) {
+        switch deepLinkRoute {
+        case let .session(sessionId, pendingItemId):
+            guard let sessionId = sessionId.nilIfBlank else {
+                return nil
+            }
+            if let pendingItemId = pendingItemId?.nilIfBlank {
+                self = .pendingItem(pendingItemId: pendingItemId, sessionId: sessionId)
+            } else {
+                self = .session(sessionId: sessionId)
+            }
+        case let .pendingItem(pendingItemId, sessionId):
+            guard let pendingItemId = pendingItemId.nilIfBlank else {
+                return nil
+            }
+            self = .pendingItem(pendingItemId: pendingItemId, sessionId: sessionId?.nilIfBlank)
+        }
+    }
+
+    public var deepLinkRoute: CockpitDeepLinkRoute {
+        switch self {
+        case let .session(sessionId):
+            .session(sessionId: sessionId, pendingItemId: nil)
+        case let .pendingItem(pendingItemId, sessionId):
+            .pendingItem(pendingItemId: pendingItemId, sessionId: sessionId)
+        }
+    }
+}
+
+public struct CockpitNotificationRouter: Sendable {
+    private let deepLinkParser: CockpitDeepLinkParser
+    private let routeURLUserInfoKey = "codeEverywhere.routeURL"
+
+    public init(deepLinkParser: CockpitDeepLinkParser = CockpitDeepLinkParser()) {
+        self.deepLinkParser = deepLinkParser
+    }
+
+    public func deepLinkURL(for route: CockpitNotificationRoute) -> URL {
+        var components = URLComponents()
+        components.scheme = "code-everywhere"
+        switch route {
+        case let .session(sessionId):
+            components.host = "session"
+            components.percentEncodedPath = "/\(percentEncodePathSegment(sessionId))"
+        case let .pendingItem(pendingItemId, sessionId):
+            components.host = "pending"
+            components.percentEncodedPath = "/\(percentEncodePathSegment(pendingItemId))"
+            if let sessionId = sessionId?.nilIfBlank {
+                components.queryItems = [URLQueryItem(name: "session", value: sessionId)]
+            }
+        }
+
+        return components.url ?? URL(string: "code-everywhere://")!
+    }
+
+    public func userInfo(for route: CockpitNotificationRoute) -> [String: String] {
+        [routeURLUserInfoKey: deepLinkURL(for: route).absoluteString]
+    }
+
+    public func route(from url: URL) -> CockpitNotificationRoute? {
+        guard let route = deepLinkParser.parse(url) else {
+            return nil
+        }
+        return CockpitNotificationRoute(deepLinkRoute: route)
+    }
+
+    public func route(from userInfo: [AnyHashable: Any]) -> CockpitNotificationRoute? {
+        guard let routeURL = userInfo[routeURLUserInfoKey] as? String,
+              let url = URL(string: routeURL)
+        else {
+            return nil
+        }
+
+        return route(from: url)
+    }
+
+    private func percentEncodePathSegment(_ value: String) -> String {
+        var allowed = CharacterSet.urlPathAllowed
+        allowed.remove(charactersIn: "/?#")
+        return value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
+    }
+}

--- a/apps/apple/Tests/CodeEverywhereAppleCoreTests/CockpitNotificationRouteTests.swift
+++ b/apps/apple/Tests/CodeEverywhereAppleCoreTests/CockpitNotificationRouteTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Testing
+
+@testable import CodeEverywhereAppleCore
+
+@Suite("Cockpit notification routing")
+struct CockpitNotificationRouteTests {
+    private let router = CockpitNotificationRouter()
+
+    @Test("creates session notification deep links")
+    func createsSessionDeepLinks() {
+        let url = router.deepLinkURL(for: .session(sessionId: "session-123"))
+
+        #expect(url.absoluteString == "code-everywhere://session/session-123")
+        #expect(router.route(from: url)?.deepLinkRoute == .session(sessionId: "session-123", pendingItemId: nil))
+    }
+
+    @Test("creates pending item notification deep links")
+    func createsPendingItemDeepLinks() {
+        let url = router.deepLinkURL(for: .pendingItem(pendingItemId: "approval-9", sessionId: "session-123"))
+
+        #expect(url.absoluteString == "code-everywhere://pending/approval-9?session=session-123")
+        #expect(router.route(from: url)?.deepLinkRoute == .pendingItem(pendingItemId: "approval-9", sessionId: "session-123"))
+    }
+
+    @Test("round trips notification user info")
+    func roundTripsNotificationUserInfo() {
+        let route = CockpitNotificationRoute.pendingItem(pendingItemId: "input with spaces", sessionId: "session-123")
+        let userInfo = router.userInfo(for: route)
+
+        #expect(userInfo == ["codeEverywhere.routeURL": "code-everywhere://pending/input%20with%20spaces?session=session-123"])
+        #expect(router.route(from: userInfo)?.deepLinkRoute == .pendingItem(pendingItemId: "input with spaces", sessionId: "session-123"))
+    }
+
+    @Test("preserves pending item from session links")
+    func preservesPendingItemFromSessionLinks() throws {
+        let url = try #require(URL(string: "code-everywhere://session/session-123?pending=approval-9"))
+
+        #expect(router.route(from: url)?.deepLinkRoute == .pendingItem(pendingItemId: "approval-9", sessionId: "session-123"))
+    }
+
+    @Test("rejects unsupported notification user info")
+    func rejectsUnsupportedUserInfo() {
+        #expect(router.route(from: ["codeEverywhere.routeURL": "code-everywhere://settings"]) == nil)
+        #expect(router.route(from: ["other": "code-everywhere://session/session-123"]) == nil)
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,6 +104,12 @@ and simulator-buildable with `CODE_SIGNING_ALLOWED=NO`. It launches the shared
 cockpit web-view shell and consumes the package-owned connection settings,
 Keychain-backed token storage, and deep-link parsing.
 
+Notification routing starts in Apple core as route metadata, not APNs delivery.
+Native notification payloads should carry a `code-everywhere://` route URL that
+round-trips through the same session and pending-item parser used by the app
+shell. APNs registration, device-token upload, and notification permission UX
+remain separate platform work.
+
 ## Protocol Principles
 
 - Use explicit event types and command types.

--- a/docs/product-goals.md
+++ b/docs/product-goals.md
@@ -44,4 +44,10 @@ The UI should optimize for scanning and action, not spectacle.
 
 iOS, iPadOS, and macOS are first-class targets. A PWA can be useful for fast iteration, but the product should be ready for a native wrapper or native client because notifications, deep links, Keychain, and OS integration are part of the experience.
 
-The first Apple checkpoint is a native Apple wrapper around the shared web cockpit rather than a PWA-only path or full native rewrite. Native code should start by owning platform concerns such as Keychain storage, notification registration, notification actions, deep links, and device identity while the React cockpit remains the shared session and operator workflow surface.
+The first Apple checkpoint is a native Apple wrapper around the shared web
+cockpit rather than a PWA-only path or full native rewrite. Native code should
+start by owning platform concerns such as Keychain storage, notification
+routing, notification actions, deep links, and device identity while the React
+cockpit remains the shared session and operator workflow surface. APNs
+registration and device-token upload should follow only after local
+notification routes and device identity are explicit.


### PR DESCRIPTION
## Summary
- add Apple core notification route metadata that round-trips through existing cockpit deep links
- support session and pending-item notification URLs plus userInfo payloads without APNs registration or device-token upload
- wire the app shell open-url path through the notification router before falling back to the existing parser
- document notification routing as local route scaffolding, not APNs delivery

## Validation
- pnpm apple:test
- pnpm apple:build
- pnpm apple:app:build
- pnpm lint:dry-run
- pnpm validate