### PR TITLE
Add Apple device identity scaffold

### DIFF
--- a/apps/apple/Sources/CodeEverywhereAppleCore/AppleDeviceIdentity.swift
+++ b/apps/apple/Sources/CodeEverywhereAppleCore/AppleDeviceIdentity.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+public struct AppleDeviceIdentity: Codable, Equatable, Sendable {
+    public var deviceId: String
+    public var displayName: String
+    public var platform: String
+    public var createdAt: Date
+    public var lastSeenAt: Date
+
+    public init(
+        deviceId: String,
+        displayName: String,
+        platform: String,
+        createdAt: Date,
+        lastSeenAt: Date
+    ) {
+        self.deviceId = deviceId
+        self.displayName = displayName.nilIfBlank ?? "Apple Device"
+        self.platform = platform.nilIfBlank ?? "apple"
+        self.createdAt = createdAt
+        self.lastSeenAt = lastSeenAt
+    }
+}
+
+public struct AppleDeviceIdentityStore {
+    private let defaults: UserDefaults
+    private let identityKey: String
+    private let makeUUID: () -> UUID
+    private let now: () -> Date
+    private let defaultDisplayName: () -> String
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    public init(
+        defaults: UserDefaults = .standard,
+        namespace: String = "CodeEverywhere",
+        makeUUID: @escaping () -> UUID = UUID.init,
+        now: @escaping () -> Date = Date.init,
+        defaultDisplayName: @escaping () -> String = AppleDeviceIdentityStore.defaultDeviceName
+    ) {
+        self.defaults = defaults
+        self.identityKey = "\(namespace).appleDeviceIdentity"
+        self.makeUUID = makeUUID
+        self.now = now
+        self.defaultDisplayName = defaultDisplayName
+        encoder.dateEncodingStrategy = .iso8601
+        decoder.dateDecodingStrategy = .iso8601
+    }
+
+    public func load() throws -> AppleDeviceIdentity? {
+        guard let data = defaults.data(forKey: identityKey) else {
+            return nil
+        }
+
+        return try decoder.decode(AppleDeviceIdentity.self, from: data)
+    }
+
+    public func loadOrCreate() throws -> AppleDeviceIdentity {
+        if let identity = try load() {
+            return identity
+        }
+
+        let timestamp = now()
+        let identity = AppleDeviceIdentity(
+            deviceId: "apple-\(makeUUID().uuidString.lowercased())",
+            displayName: defaultDisplayName(),
+            platform: "apple",
+            createdAt: timestamp,
+            lastSeenAt: timestamp
+        )
+        try save(identity)
+        return identity
+    }
+
+    public func touch() throws -> AppleDeviceIdentity {
+        var identity = try loadOrCreate()
+        identity.lastSeenAt = now()
+        try save(identity)
+        return identity
+    }
+
+    public func save(_ identity: AppleDeviceIdentity) throws {
+        defaults.set(try encoder.encode(identity), forKey: identityKey)
+    }
+
+    public func clear() {
+        defaults.removeObject(forKey: identityKey)
+    }
+
+    public static func defaultDeviceName() -> String {
+        ProcessInfo.processInfo.hostName.nilIfBlank ?? "Apple Device"
+    }
+}

--- a/apps/apple/Tests/CodeEverywhereAppleCoreTests/AppleDeviceIdentityTests.swift
+++ b/apps/apple/Tests/CodeEverywhereAppleCoreTests/AppleDeviceIdentityTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+
+@testable import CodeEverywhereAppleCore
+
+@Suite("Apple device identity")
+struct AppleDeviceIdentityTests {
+    @Test("creates and persists a stable local device identity")
+    func createsStableIdentity() throws {
+        let defaults = makeDefaults()
+        let store = AppleDeviceIdentityStore(
+            defaults: defaults,
+            namespace: "device",
+            makeUUID: { UUID(uuidString: "A7EF70B7-0255-47D6-82E5-8E7EA4E9A63E")! },
+            now: { Date(timeIntervalSince1970: 100) },
+            defaultDisplayName: { " Casey's iPad " }
+        )
+
+        let created = try store.loadOrCreate()
+        let loaded = try store.loadOrCreate()
+
+        #expect(created == loaded)
+        #expect(created.deviceId == "apple-a7ef70b7-0255-47d6-82e5-8e7ea4e9a63e")
+        #expect(created.displayName == "Casey's iPad")
+        #expect(created.platform == "apple")
+        #expect(created.createdAt == Date(timeIntervalSince1970: 100))
+        #expect(created.lastSeenAt == Date(timeIntervalSince1970: 100))
+    }
+
+    @Test("updates last seen without changing the device id")
+    func touchesIdentity() throws {
+        var currentTime = Date(timeIntervalSince1970: 100)
+        let store = AppleDeviceIdentityStore(
+            defaults: makeDefaults(),
+            namespace: "touch",
+            makeUUID: { UUID(uuidString: "A7EF70B7-0255-47D6-82E5-8E7EA4E9A63E")! },
+            now: { currentTime },
+            defaultDisplayName: { "MacBook Pro" }
+        )
+
+        let created = try store.loadOrCreate()
+        currentTime = Date(timeIntervalSince1970: 200)
+        let touched = try store.touch()
+
+        #expect(touched.deviceId == created.deviceId)
+        #expect(touched.createdAt == Date(timeIntervalSince1970: 100))
+        #expect(touched.lastSeenAt == Date(timeIntervalSince1970: 200))
+    }
+
+    @Test("stores only non-secret metadata in user defaults")
+    func storesOnlyNonSecretMetadata() throws {
+        let defaults = makeDefaults()
+        let store = AppleDeviceIdentityStore(defaults: defaults, namespace: "plain")
+
+        _ = try store.loadOrCreate()
+
+        #expect(defaults.dictionaryRepresentation().keys.contains("plain.appleDeviceIdentity"))
+        #expect(defaults.dictionaryRepresentation().keys.allSatisfy { !$0.localizedCaseInsensitiveContains("token") })
+        #expect(defaults.dictionaryRepresentation().keys.allSatisfy { !$0.localizedCaseInsensitiveContains("secret") })
+    }
+
+    @Test("clears the local identity")
+    func clearsIdentity() throws {
+        let store = AppleDeviceIdentityStore(defaults: makeDefaults(), namespace: "clear")
+        _ = try store.loadOrCreate()
+
+        store.clear()
+
+        #expect(try store.load() == nil)
+    }
+
+    private func makeDefaults() -> UserDefaults {
+        let suiteName = "CodeEverywhereAppleDeviceIdentityTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -110,6 +110,12 @@ round-trips through the same session and pending-item parser used by the app
 shell. APNs registration, device-token upload, and notification permission UX
 remain separate platform work.
 
+Device identity starts as a local Apple core record, also before APNs delivery.
+It stores non-secret install metadata in user defaults and reserves Keychain or
+another `SecretStore` implementation for future device-held credentials. The
+broker trust registry can later reference that device id when host, operator,
+and device trust become linked product state.
+
 ## Protocol Principles
 
 - Use explicit event types and command types.

--- a/docs/every-code-integration.md
+++ b/docs/every-code-integration.md
@@ -79,6 +79,13 @@ to add are:
 - an operator/account identifier for clients that can enqueue commands
 - a device identifier for native clients and notification routing
 
+Apple clients create a local install-scoped device identity before APNs work.
+That identity is non-secret metadata: a stable device id, display label,
+platform, creation timestamp, and last-seen timestamp. It can later be mirrored
+into the broker trust registry as a trusted device record. Push tokens,
+device-held credentials, and any signing or registration secrets must stay out
+of user defaults and behind Keychain or another `SecretStore` implementation.
+
 The first Apple-client shell should be a native wrapper around the shared web
 cockpit. It should use the same broker snapshot, command, and trust APIs as the
 web client while native code handles device-held secrets, notification


### PR DESCRIPTION
## Summary
- add Apple core local device identity metadata and a UserDefaults-backed store
- keep the record non-secret: stable device id, display label, platform, created timestamp, and last-seen timestamp
- add Swift tests for stable creation, touch updates, clearing, and avoiding token/secret defaults keys
- document that APNs registration, push tokens, and device-held credentials remain deferred behind SecretStore/Keychain boundaries

## Validation
- pnpm apple:test
- pnpm apple:build
- pnpm apple:app:build
- pnpm lint:dry-run
- pnpm validate