### PR TITLE
Add Apple device trust registration

### DIFF
--- a/apps/apple/Sources/CodeEverywhereAppleCore/AppleDeviceIdentity.swift
+++ b/apps/apple/Sources/CodeEverywhereAppleCore/AppleDeviceIdentity.swift
@@ -20,6 +20,69 @@ public struct AppleDeviceIdentity: Codable, Equatable, Sendable {
         self.createdAt = createdAt
         self.lastSeenAt = lastSeenAt
     }
+
+    public func trustRecord(status: AppleDeviceTrustStatus = .trusted) -> AppleDeviceTrustRecord {
+        AppleDeviceTrustRecord(
+            deviceId: deviceId,
+            label: displayName,
+            platform: platform,
+            createdAt: createdAt,
+            lastSeenAt: lastSeenAt,
+            status: status
+        )
+    }
+
+    public func trustRegistrationPayload(status: AppleDeviceTrustStatus = .trusted) -> AppleDeviceTrustRegistrationPayload {
+        AppleDeviceTrustRegistrationPayload(device: trustRecord(status: status))
+    }
+}
+
+public enum AppleDeviceTrustStatus: String, Codable, Equatable, Sendable {
+    case trusted
+    case revoked
+}
+
+public struct AppleDeviceTrustRecord: Codable, Equatable, Sendable {
+    public var deviceId: String
+    public var label: String
+    public var platform: String
+    public var createdAt: Date
+    public var lastSeenAt: Date?
+    public var status: AppleDeviceTrustStatus
+
+    public init(
+        deviceId: String,
+        label: String,
+        platform: String,
+        createdAt: Date,
+        lastSeenAt: Date?,
+        status: AppleDeviceTrustStatus
+    ) {
+        self.deviceId = deviceId
+        self.label = label.nilIfBlank ?? "Apple Device"
+        self.platform = platform.nilIfBlank ?? "apple"
+        self.createdAt = createdAt
+        self.lastSeenAt = lastSeenAt
+        self.status = status
+    }
+}
+
+public struct AppleDeviceTrustRegistrationPayload: Codable, Equatable, Sendable {
+    public var device: AppleDeviceTrustRecord
+
+    public init(device: AppleDeviceTrustRecord) {
+        self.device = device
+    }
+
+    public static func brokerJSONEncoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    public func brokerJSONData() throws -> Data {
+        try Self.brokerJSONEncoder().encode(self)
+    }
 }
 
 public struct AppleDeviceIdentityStore {

--- a/apps/apple/Tests/CodeEverywhereAppleCoreTests/AppleDeviceIdentityTests.swift
+++ b/apps/apple/Tests/CodeEverywhereAppleCoreTests/AppleDeviceIdentityTests.swift
@@ -59,6 +59,37 @@ struct AppleDeviceIdentityTests {
         #expect(defaults.dictionaryRepresentation().keys.allSatisfy { !$0.localizedCaseInsensitiveContains("secret") })
     }
 
+    @Test("creates broker device trust registration payloads")
+    func createsTrustRegistrationPayloads() throws {
+        let identity = AppleDeviceIdentity(
+            deviceId: "apple-device-1",
+            displayName: "Casey's iPad",
+            platform: "apple",
+            createdAt: Date(timeIntervalSince1970: 100),
+            lastSeenAt: Date(timeIntervalSince1970: 200)
+        )
+
+        #expect(identity.trustRegistrationPayload() == AppleDeviceTrustRegistrationPayload(device: AppleDeviceTrustRecord(
+            deviceId: "apple-device-1",
+            label: "Casey's iPad",
+            platform: "apple",
+            createdAt: Date(timeIntervalSince1970: 100),
+            lastSeenAt: Date(timeIntervalSince1970: 200),
+            status: .trusted
+        )))
+
+        let data = try identity.trustRegistrationPayload().brokerJSONData()
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let device = json?["device"] as? [String: Any]
+
+        #expect(device?["deviceId"] as? String == "apple-device-1")
+        #expect(device?["label"] as? String == "Casey's iPad")
+        #expect(device?["platform"] as? String == "apple")
+        #expect(device?["createdAt"] as? String == "1970-01-01T00:01:40Z")
+        #expect(device?["lastSeenAt"] as? String == "1970-01-01T00:03:20Z")
+        #expect(device?["status"] as? String == "trusted")
+    }
+
     @Test("clears the local identity")
     func clearsIdentity() throws {
         let store = AppleDeviceIdentityStore(defaults: makeDefaults(), namespace: "clear")

--- a/apps/web/src/cockpitTrust.test.ts
+++ b/apps/web/src/cockpitTrust.test.ts
@@ -5,8 +5,10 @@ import {
     canManageTrust,
     createTrustUrl,
     fetchLocalTrustRegistry,
+    postRevokedDeviceId,
     postRevokedHost,
     postRevokedHostId,
+    postTrustedDevice,
     postTrustedHost,
 } from "./cockpitTrust"
 
@@ -26,6 +28,14 @@ describe("cockpit trust client", () => {
             },
         ],
         devices: [],
+    }
+    const device = {
+        deviceId: "apple-device-1",
+        label: "Casey's iPad",
+        platform: "apple",
+        createdAt: "2026-04-29T19:49:00.000Z",
+        lastSeenAt: "2026-04-29T19:50:00.000Z",
+        status: "trusted" as const,
     }
 
     it("builds trust URLs from a configured transport root", () => {
@@ -115,6 +125,35 @@ describe("cockpit trust client", () => {
         })
     })
 
+    it("posts and revokes trusted device records", async () => {
+        const requests: { url: string; init: RequestInit | undefined }[] = []
+        const fetchImpl: Parameters<typeof postTrustedDevice>[2] = (input, init) => {
+            requests.push({ url: toRequestUrl(input), init })
+            return Promise.resolve(new Response(JSON.stringify({ ...trustSnapshot, devices: [device] }), { status: 200 }))
+        }
+
+        await expect(postTrustedDevice("http://127.0.0.1:4789", device, fetchImpl)).resolves.toMatchObject({
+            devices: [{ deviceId: "apple-device-1", platform: "apple", status: "trusted" }],
+        })
+        await expect(postRevokedDeviceId("http://127.0.0.1:4789", " apple-device-1 ", now, fetchImpl)).resolves.toMatchObject({
+            devices: [{ deviceId: "apple-device-1" }],
+        })
+        await expect(postRevokedDeviceId("http://127.0.0.1:4789", " ", now, fetchImpl)).rejects.toThrow("Device id is required")
+
+        expect(requests.map((request) => request.url)).toEqual([
+            "http://127.0.0.1:4789/trust/devices",
+            "http://127.0.0.1:4789/trust/devices/revoke",
+        ])
+        expect(requests[0]?.init).toMatchObject({
+            method: "POST",
+            body: JSON.stringify({ device }),
+        })
+        expect(requests[1]?.init).toMatchObject({
+            method: "POST",
+            body: JSON.stringify({ deviceId: "apple-device-1", revokedAt: "2026-04-29T19:50:00.000Z" }),
+        })
+    })
+
     it("rejects missing host ids and malformed responses", async () => {
         const missingHostSession = { ...session }
         delete missingHostSession.hostId
@@ -137,6 +176,13 @@ describe("cockpit trust client", () => {
         await expect(fetchLocalTrustRegistry("http://127.0.0.1:4789", malformedFetch)).rejects.toThrow(
             "Cockpit trust response did not match the expected shape",
         )
+        await expect(
+            fetchLocalTrustRegistry("http://127.0.0.1:4789", () =>
+                Promise.resolve(
+                    new Response(JSON.stringify({ ...trustSnapshot, devices: [{ deviceId: "apple-device-1" }] }), { status: 200 }),
+                ),
+            ),
+        ).rejects.toThrow("Cockpit trust response did not match the expected shape")
     })
 })
 

--- a/apps/web/src/cockpitTrust.ts
+++ b/apps/web/src/cockpitTrust.ts
@@ -1,4 +1,4 @@
-import type { LocalHostTrustRecord, LocalTrustRegistrySnapshot } from "@code-everywhere/server/trust"
+import type { LocalDeviceTrustRecord, LocalHostTrustRecord, LocalTrustRegistrySnapshot } from "@code-everywhere/server/trust"
 
 import type { CockpitSession } from "./cockpitData"
 import type { CockpitTransportStatus } from "./cockpitTransport"
@@ -60,6 +60,26 @@ export const postRevokedHostId = async (
     }
 
     return postTrustJson(transportUrl, "hosts/revoke", { hostId: normalizedHostId, revokedAt: now().toISOString() }, fetchImpl)
+}
+
+export const postTrustedDevice = async (
+    transportUrl: string,
+    device: LocalDeviceTrustRecord,
+    fetchImpl: FetchLike = globalThis.fetch,
+): Promise<LocalTrustRegistrySnapshot> => postTrustJson(transportUrl, "devices", { device }, fetchImpl)
+
+export const postRevokedDeviceId = async (
+    transportUrl: string,
+    deviceId: string,
+    now: () => Date = () => new Date(),
+    fetchImpl: FetchLike = globalThis.fetch,
+): Promise<LocalTrustRegistrySnapshot> => {
+    const normalizedDeviceId = deviceId.trim()
+    if (normalizedDeviceId === "") {
+        throw new Error("Device id is required")
+    }
+
+    return postTrustJson(transportUrl, "devices/revoke", { deviceId: normalizedDeviceId, revokedAt: now().toISOString() }, fetchImpl)
 }
 
 export const fetchLocalTrustRegistry = async (
@@ -138,12 +158,21 @@ const isLocalTrustRegistrySnapshot = (value: unknown): value is LocalTrustRegist
     value.version === 1 &&
     (value.operator === null || isRecord(value.operator)) &&
     isArrayOf(value.hosts, isHostTrustRecord) &&
-    Array.isArray(value.devices)
+    isArrayOf(value.devices, isDeviceTrustRecord)
 
 const isHostTrustRecord = (value: unknown): value is LocalHostTrustRecord =>
     isRecord(value) &&
     typeof value.hostId === "string" &&
     typeof value.label === "string" &&
+    typeof value.createdAt === "string" &&
+    (value.lastSeenAt === null || typeof value.lastSeenAt === "string") &&
+    (value.status === "trusted" || value.status === "revoked")
+
+const isDeviceTrustRecord = (value: unknown): value is LocalDeviceTrustRecord =>
+    isRecord(value) &&
+    typeof value.deviceId === "string" &&
+    typeof value.label === "string" &&
+    (value.platform === undefined || typeof value.platform === "string") &&
     typeof value.createdAt === "string" &&
     (value.lastSeenAt === null || typeof value.lastSeenAt === "string") &&
     (value.status === "trusted" || value.status === "revoked")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,7 +74,8 @@ continues to own the trusted-record list for the local deployment mode. Broker
 snapshots derive session trust from projected `hostId` and the host registry;
 sessions without a host id remain explicit unverified legacy sessions. The local
 broker exposes a narrow trust API for inspecting the registry and upserting or
-revoking host records; it does not store route auth tokens in trust records.
+revoking host and native device records; it does not store route auth tokens,
+APNs tokens, or device-held secrets in trust records.
 
 ### Clients
 

--- a/docs/every-code-integration.md
+++ b/docs/every-code-integration.md
@@ -150,6 +150,10 @@ Every Code adapter that consumes them:
 - local trust records can be inspected with `GET /trust`; trusted host records
   can be upserted with `POST /trust/hosts`, and hosts can be revoked with
   `POST /trust/hosts/revoke`
+- trusted Apple/native device records can be upserted with
+  `POST /trust/devices`, and devices can be revoked with
+  `POST /trust/devices/revoke`; these records must not include APNs tokens or
+  device-held secrets
 - web clients pass broker auth with `VITE_COCKPIT_AUTH_TOKEN` when the broker is
   started with a token
 

--- a/packages/server/src/http.test.ts
+++ b/packages/server/src/http.test.ts
@@ -217,7 +217,7 @@ describe("cockpit HTTP transport", () => {
         }
     })
 
-    it("manages trusted host records through local trust routes", async () => {
+    it("manages trusted host and device records through local trust routes", async () => {
         const trustStore = createLocalTrustRegistryStore()
         const trustServer = createCockpitHttpServer({ trustStore })
         let trustBaseUrl: string
@@ -264,6 +264,33 @@ describe("cockpit HTTP transport", () => {
                     hosts: [{ ...host, lastSeenAt: "2026-04-29T19:45:00.000Z", status: "revoked" }],
                 },
             })
+
+            const device = {
+                deviceId: "apple-device-1",
+                label: "Casey's iPad",
+                platform: "apple",
+                createdAt: "2026-04-29T19:46:00.000Z",
+                lastSeenAt: "2026-04-29T19:47:00.000Z",
+                status: "trusted",
+            }
+            await expect(sendJson(trustBaseUrl, "POST", "/trust/devices", { device })).resolves.toMatchObject({
+                statusCode: 200,
+                body: {
+                    devices: [device],
+                },
+            })
+
+            await expect(
+                sendJson(trustBaseUrl, "POST", "/trust/devices/revoke", {
+                    deviceId: "apple-device-1",
+                    revokedAt: "2026-04-29T19:48:00.000Z",
+                }),
+            ).resolves.toMatchObject({
+                statusCode: 200,
+                body: {
+                    devices: [{ ...device, lastSeenAt: "2026-04-29T19:48:00.000Z", status: "revoked" }],
+                },
+            })
         } finally {
             await new Promise<void>((resolve) => trustServer.close(() => resolve()))
         }
@@ -277,6 +304,14 @@ describe("cockpit HTTP transport", () => {
         await expect(sendJson(baseUrl, "POST", "/trust/hosts/revoke", { hostId: "host-workhorse" })).resolves.toMatchObject({
             statusCode: 400,
             body: { error: "Expected hostId and revokedAt strings" },
+        })
+        await expect(sendJson(baseUrl, "POST", "/trust/devices", { deviceId: "apple-device-1" })).resolves.toMatchObject({
+            statusCode: 400,
+            body: { error: "Expected one local device trust record" },
+        })
+        await expect(sendJson(baseUrl, "POST", "/trust/devices/revoke", { deviceId: "apple-device-1" })).resolves.toMatchObject({
+            statusCode: 400,
+            body: { error: "Expected deviceId and revokedAt strings" },
         })
         await expect(sendJson(baseUrl, "PUT", "/trust", {})).resolves.toMatchObject({
             statusCode: 405,

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -27,6 +27,7 @@ import {
 } from "./index.js"
 import {
     createLocalTrustRegistryStore,
+    type LocalDeviceTrustRecord,
     type LocalHostTrustRecord,
     type LocalTrustRegistrySnapshot,
     type LocalTrustRegistryStore,
@@ -242,6 +243,40 @@ const routeRequest = async (
         return
     }
 
+    if (url.pathname === "/trust/devices") {
+        if (request.method !== "POST") {
+            writeMethodNotAllowed(response, "POST")
+            return
+        }
+
+        const body = await readJsonBody(request, maxBodyBytes)
+        const device = normalizeDeviceTrustPayload(body)
+        if (device === null) {
+            writeJson(response, 400, { error: "Expected one local device trust record" })
+            return
+        }
+
+        writeJson(response, 200, trustStore.upsertDevice(device))
+        return
+    }
+
+    if (url.pathname === "/trust/devices/revoke") {
+        if (request.method !== "POST") {
+            writeMethodNotAllowed(response, "POST")
+            return
+        }
+
+        const body = await readJsonBody(request, maxBodyBytes)
+        const payload = normalizeDeviceRevokePayload(body)
+        if (payload === null) {
+            writeJson(response, 400, { error: "Expected deviceId and revokedAt strings" })
+            return
+        }
+
+        writeJson(response, 200, trustStore.revokeDevice(payload.deviceId, payload.revokedAt))
+        return
+    }
+
     if (url.pathname === "/reset") {
         if (request.method !== "POST") {
             writeMethodNotAllowed(response, "POST")
@@ -394,6 +429,15 @@ const normalizeHostTrustPayload = (payload: unknown): LocalHostTrustRecord | nul
     return { ...host }
 }
 
+const normalizeDeviceTrustPayload = (payload: unknown): LocalDeviceTrustRecord | null => {
+    const device = isRecord(payload) && "device" in payload ? payload.device : payload
+    if (!isDeviceTrustRecord(device)) {
+        return null
+    }
+
+    return { ...device }
+}
+
 const normalizeHostRevokePayload = (payload: unknown): { hostId: string; revokedAt: string } | null => {
     if (!isRecord(payload) || !hasString(payload, "hostId") || !hasString(payload, "revokedAt")) {
         return null
@@ -401,6 +445,17 @@ const normalizeHostRevokePayload = (payload: unknown): { hostId: string; revoked
 
     return {
         hostId: String(payload.hostId),
+        revokedAt: String(payload.revokedAt),
+    }
+}
+
+const normalizeDeviceRevokePayload = (payload: unknown): { deviceId: string; revokedAt: string } | null => {
+    if (!isRecord(payload) || !hasString(payload, "deviceId") || !hasString(payload, "revokedAt")) {
+        return null
+    }
+
+    return {
+        deviceId: String(payload.deviceId),
         revokedAt: String(payload.revokedAt),
     }
 }
@@ -417,6 +472,15 @@ const isHostTrustRecord = (value: unknown): value is LocalHostTrustRecord =>
     isRecord(value) &&
     hasString(value, "hostId") &&
     hasString(value, "label") &&
+    hasString(value, "createdAt") &&
+    hasNullableString(value, "lastSeenAt") &&
+    hasEnum(value, "status", ["trusted", "revoked"] as const)
+
+const isDeviceTrustRecord = (value: unknown): value is LocalDeviceTrustRecord =>
+    isRecord(value) &&
+    hasString(value, "deviceId") &&
+    hasString(value, "label") &&
+    hasOptionalString(value, "platform") &&
     hasString(value, "createdAt") &&
     hasNullableString(value, "lastSeenAt") &&
     hasEnum(value, "status", ["trusted", "revoked"] as const)

--- a/packages/server/src/trust.test.ts
+++ b/packages/server/src/trust.test.ts
@@ -34,6 +34,7 @@ const host: LocalHostTrustRecord = {
 const device: LocalDeviceTrustRecord = {
     deviceId: "device-phone",
     label: "Callisto iPhone",
+    platform: "apple",
     createdAt,
     lastSeenAt: "2026-04-29T18:02:00.000Z",
     status: "trusted",

--- a/packages/server/src/trust.ts
+++ b/packages/server/src/trust.ts
@@ -22,6 +22,7 @@ export type LocalHostTrustRecord = {
 export type LocalDeviceTrustRecord = {
     deviceId: string
     label: string
+    platform?: string
     createdAt: string
     lastSeenAt: string | null
     status: LocalTrustRecordStatus
@@ -212,6 +213,7 @@ const isDeviceTrustRecord = (value: unknown): value is LocalDeviceTrustRecord =>
     isRecord(value) &&
     isString(value.deviceId) &&
     isString(value.label) &&
+    (value.platform === undefined || isString(value.platform)) &&
     isString(value.createdAt) &&
     isNullableString(value.lastSeenAt) &&
     isTrustRecordStatus(value.status)


### PR DESCRIPTION
## Summary

- Add broker HTTP routes for trusted Apple device records and revocation.
- Add web trust-client helpers plus stricter device snapshot validation.
- Add Apple device trust payload generation with broker JSON encoding for ISO8601 timestamps.
- Document the host/device trust boundary and the no-secret/no-APNs-token constraint.

## Validation

- `pnpm apple:test` passed: 16 tests in 4 suites.
- `pnpm apple:app:build` passed for `generic/platform=iOS Simulator` with `CODE_SIGNING_ALLOWED=NO`.
- `pnpm lint:dry-run` passed.
- `pnpm validate` passed: contracts 14 tests, server 52 tests, web 39 tests.
- `pnpm smoke:cockpit:web` passed at `http://127.0.0.1:52154` using broker `http://127.0.0.1:52153`.
