### PR TITLE
Add Apple device trust client flow

### DIFF
--- a/apps/apple/Sources/CodeEverywhereAppleCore/AppleDeviceTrustClient.swift
+++ b/apps/apple/Sources/CodeEverywhereAppleCore/AppleDeviceTrustClient.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+public struct AppleDeviceTrustHTTPResponse: Equatable, Sendable {
+    public var statusCode: Int
+    public var data: Data
+
+    public init(statusCode: Int, data: Data) {
+        self.statusCode = statusCode
+        self.data = data
+    }
+}
+
+public protocol AppleDeviceTrustHTTPTransport: Sendable {
+    func send(_ request: URLRequest) async throws -> AppleDeviceTrustHTTPResponse
+}
+
+public struct URLSessionAppleDeviceTrustHTTPTransport: AppleDeviceTrustHTTPTransport, @unchecked Sendable {
+    private let session: URLSession
+
+    public init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    public func send(_ request: URLRequest) async throws -> AppleDeviceTrustHTTPResponse {
+        let (data, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw AppleDeviceTrustClientError.invalidHTTPResponse
+        }
+
+        return AppleDeviceTrustHTTPResponse(statusCode: httpResponse.statusCode, data: data)
+    }
+}
+
+public enum AppleDeviceTrustClientError: Error, Equatable {
+    case missingBrokerURL
+    case invalidHTTPResponse
+    case requestFailed(Int)
+    case invalidResponseBody
+}
+
+public struct AppleLocalTrustRegistrySnapshot: Decodable, Equatable, Sendable {
+    public var version: Int
+    public var devices: [AppleDeviceTrustRecord]
+
+    public init(version: Int, devices: [AppleDeviceTrustRecord]) {
+        self.version = version
+        self.devices = devices
+    }
+}
+
+public struct AppleDeviceTrustClient: Sendable {
+    private let transport: any AppleDeviceTrustHTTPTransport
+
+    public init(transport: any AppleDeviceTrustHTTPTransport = URLSessionAppleDeviceTrustHTTPTransport()) {
+        self.transport = transport
+    }
+
+    public func fetchRegistry(settings: CockpitConnectionSettings) async throws -> AppleLocalTrustRegistrySnapshot {
+        try await sendTrustRequest(pathComponents: ["trust"], settings: settings, method: "GET")
+    }
+
+    public func registerDevice(
+        identity: AppleDeviceIdentity,
+        settings: CockpitConnectionSettings
+    ) async throws -> AppleLocalTrustRegistrySnapshot {
+        let payload = identity.trustRegistrationPayload()
+        return try await sendTrustRequest(
+            pathComponents: ["trust", "devices"],
+            settings: settings,
+            method: "POST",
+            body: payload.brokerJSONData()
+        )
+    }
+
+    public func revokeDevice(
+        identity: AppleDeviceIdentity,
+        settings: CockpitConnectionSettings,
+        revokedAt: Date = Date()
+    ) async throws -> AppleLocalTrustRegistrySnapshot {
+        let payload = AppleDeviceTrustRevocationPayload(deviceId: identity.deviceId, revokedAt: revokedAt)
+        return try await sendTrustRequest(
+            pathComponents: ["trust", "devices", "revoke"],
+            settings: settings,
+            method: "POST",
+            body: payload.brokerJSONData()
+        )
+    }
+
+    private func sendTrustRequest(
+        pathComponents: [String],
+        settings: CockpitConnectionSettings,
+        method: String,
+        body: Data? = nil
+    ) async throws -> AppleLocalTrustRegistrySnapshot {
+        guard let brokerURL = settings.brokerURL else {
+            throw AppleDeviceTrustClientError.missingBrokerURL
+        }
+
+        var request = URLRequest(url: trustURL(baseURL: brokerURL, pathComponents: pathComponents))
+        request.httpMethod = method
+        request.httpBody = body
+        request.setValue("application/json", forHTTPHeaderField: "accept")
+        if body != nil {
+            request.setValue("application/json", forHTTPHeaderField: "content-type")
+        }
+        if let token = settings.brokerAuthToken?.nilIfBlank {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "authorization")
+        }
+
+        let response = try await transport.send(request)
+        guard (200..<300).contains(response.statusCode) else {
+            throw AppleDeviceTrustClientError.requestFailed(response.statusCode)
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard let snapshot = try? decoder.decode(AppleLocalTrustRegistrySnapshot.self, from: response.data),
+              snapshot.version == 1
+        else {
+            throw AppleDeviceTrustClientError.invalidResponseBody
+        }
+
+        return snapshot
+    }
+
+    private func trustURL(baseURL: URL, pathComponents: [String]) -> URL {
+        pathComponents.reduce(baseURL) { url, component in
+            url.appendingPathComponent(component)
+        }
+    }
+}
+
+private struct AppleDeviceTrustRevocationPayload: Encodable {
+    var deviceId: String
+    var revokedAt: Date
+
+    func brokerJSONData() throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return try encoder.encode(self)
+    }
+}

--- a/apps/apple/Sources/CodeEverywhereAppleUI/AppleDeviceTrustRegistrationPanel.swift
+++ b/apps/apple/Sources/CodeEverywhereAppleUI/AppleDeviceTrustRegistrationPanel.swift
@@ -1,0 +1,242 @@
+import CodeEverywhereAppleCore
+import SwiftUI
+
+public struct AppleDeviceTrustRegistrationPanel: View {
+    private let settings: CockpitConnectionSettings
+    private let identityStore: AppleDeviceIdentityStore
+    private let client: AppleDeviceTrustClient
+
+    @State private var state = AppleDeviceTrustRegistrationPanelState.idle
+
+    public init(
+        settings: CockpitConnectionSettings,
+        identityStore: AppleDeviceIdentityStore = AppleDeviceIdentityStore(),
+        client: AppleDeviceTrustClient = AppleDeviceTrustClient()
+    ) {
+        self.settings = settings
+        self.identityStore = identityStore
+        self.client = client
+    }
+
+    public var body: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 12) {
+                statusLabel
+                Spacer(minLength: 8)
+                actionControls
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                statusLabel
+                actionControls
+            }
+        }
+        .buttonStyle(.bordered)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Color.secondary.opacity(0.08))
+        .task {
+            await refreshDeviceTrust()
+        }
+    }
+
+    private var statusLabel: some View {
+        Label {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(state.title)
+                    .font(.caption.weight(.semibold))
+                Text(state.detail)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        } icon: {
+            Image(systemName: state.systemImage)
+                .foregroundStyle(state.tint)
+        }
+        .labelStyle(.titleAndIcon)
+    }
+
+    private var actionControls: some View {
+        HStack(spacing: 8) {
+            if state.isWorking {
+                ProgressView()
+                    .controlSize(.small)
+            }
+            Button {
+                Task { await registerDevice() }
+            } label: {
+                Label("Register", systemImage: "checkmark.shield")
+            }
+            .disabled(!state.canSendCommand)
+
+            Button(role: .destructive) {
+                Task { await revokeDevice() }
+            } label: {
+                Label("Revoke", systemImage: "xmark.shield")
+            }
+            .disabled(!state.canSendCommand)
+        }
+    }
+
+    @MainActor
+    private func refreshDeviceTrust() async {
+        guard settings.brokerURL != nil else {
+            state = .missingBrokerURL
+            return
+        }
+
+        state = .checking
+        do {
+            let identity = try identityStore.loadOrCreate()
+            let snapshot = try await client.fetchRegistry(settings: settings)
+            state = panelState(identity: identity, snapshot: snapshot)
+        } catch {
+            state = .failed(message(for: error))
+        }
+    }
+
+    @MainActor
+    private func registerDevice() async {
+        state = .registering
+        do {
+            let identity = try identityStore.touch()
+            let snapshot = try await client.registerDevice(identity: identity, settings: settings)
+            state = panelState(identity: identity, snapshot: snapshot)
+        } catch {
+            state = .failed(message(for: error))
+        }
+    }
+
+    @MainActor
+    private func revokeDevice() async {
+        state = .revoking
+        do {
+            let identity = try identityStore.loadOrCreate()
+            let snapshot = try await client.revokeDevice(identity: identity, settings: settings)
+            state = panelState(identity: identity, snapshot: snapshot)
+        } catch {
+            state = .failed(message(for: error))
+        }
+    }
+
+    private func panelState(
+        identity: AppleDeviceIdentity,
+        snapshot: AppleLocalTrustRegistrySnapshot
+    ) -> AppleDeviceTrustRegistrationPanelState {
+        guard let device = snapshot.devices.first(where: { $0.deviceId == identity.deviceId }) else {
+            return .unregistered(identity.displayName)
+        }
+
+        switch device.status {
+        case .trusted:
+            return .trusted(device.label)
+        case .revoked:
+            return .revoked(device.label)
+        }
+    }
+
+    private func message(for error: Error) -> String {
+        guard let clientError = error as? AppleDeviceTrustClientError else {
+            return "Device trust request failed"
+        }
+
+        switch clientError {
+        case .missingBrokerURL:
+            return "Broker URL is not configured"
+        case .invalidHTTPResponse:
+            return "Broker response was not HTTP"
+        case let .requestFailed(statusCode):
+            return "Broker rejected device trust with HTTP \(statusCode)"
+        case .invalidResponseBody:
+            return "Broker trust response was invalid"
+        }
+    }
+}
+
+private enum AppleDeviceTrustRegistrationPanelState: Equatable {
+    case idle
+    case checking
+    case unregistered(String)
+    case trusted(String)
+    case revoked(String)
+    case registering
+    case revoking
+    case missingBrokerURL
+    case failed(String)
+
+    var title: String {
+        switch self {
+        case .idle, .checking:
+            return "Checking device trust"
+        case .unregistered:
+            return "Device not registered"
+        case .trusted:
+            return "Device trusted"
+        case .revoked:
+            return "Device revoked"
+        case .registering:
+            return "Registering device"
+        case .revoking:
+            return "Revoking device"
+        case .missingBrokerURL:
+            return "Device trust unavailable"
+        case .failed:
+            return "Device trust failed"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .idle, .checking:
+            return "Reading broker trust registry"
+        case let .unregistered(label):
+            return label
+        case let .trusted(label):
+            return label
+        case let .revoked(label):
+            return label
+        case .registering:
+            return "Sending local device identity"
+        case .revoking:
+            return "Updating broker trust registry"
+        case .missingBrokerURL:
+            return "No broker URL configured"
+        case let .failed(message):
+            return message
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .idle, .checking, .registering, .revoking:
+            return "arrow.triangle.2.circlepath"
+        case .unregistered, .missingBrokerURL:
+            return "questionmark.shield"
+        case .trusted:
+            return "checkmark.shield"
+        case .revoked, .failed:
+            return "exclamationmark.shield"
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .trusted:
+            return .green
+        case .revoked, .failed:
+            return .red
+        case .unregistered, .missingBrokerURL:
+            return .orange
+        case .idle, .checking, .registering, .revoking:
+            return .secondary
+        }
+    }
+
+    var isWorking: Bool {
+        self == .checking || self == .registering || self == .revoking
+    }
+
+    var canSendCommand: Bool {
+        !isWorking && self != .missingBrokerURL
+    }
+}

--- a/apps/apple/Sources/CodeEverywhereAppleUI/CockpitWebShell.swift
+++ b/apps/apple/Sources/CodeEverywhereAppleUI/CockpitWebShell.swift
@@ -12,8 +12,12 @@ public struct CockpitWebShell: View {
     }
 
     public var body: some View {
-        CockpitWebView(url: shellURL)
-            .navigationTitle("Code Everywhere")
+        VStack(spacing: 0) {
+            AppleDeviceTrustRegistrationPanel(settings: settings)
+            Divider()
+            CockpitWebView(url: shellURL)
+        }
+        .navigationTitle("Code Everywhere")
     }
 
     private var shellURL: URL {

--- a/apps/apple/Tests/CodeEverywhereAppleCoreTests/AppleDeviceTrustClientTests.swift
+++ b/apps/apple/Tests/CodeEverywhereAppleCoreTests/AppleDeviceTrustClientTests.swift
@@ -1,0 +1,167 @@
+import Foundation
+import Testing
+
+@testable import CodeEverywhereAppleCore
+
+@Suite("Apple device trust client")
+struct AppleDeviceTrustClientTests {
+    @Test("registers the local device with broker auth")
+    func registersLocalDevice() async throws {
+        let transport = RecordingDeviceTrustTransport(responses: [
+            AppleDeviceTrustHTTPResponse(statusCode: 200, data: snapshotData(status: "trusted")),
+        ])
+        let client = AppleDeviceTrustClient(transport: transport)
+
+        let snapshot = try await client.registerDevice(identity: identity, settings: settings(authToken: " -token "))
+
+        let request = try #require(transport.requests.first)
+        let body = try requestBody(request)
+        let device = try #require(body["device"] as? [String: Any])
+
+        #expect(request.url?.absoluteString == "http://127.0.0.1:4789/trust/devices")
+        #expect(request.httpMethod == "POST")
+        #expect(request.value(forHTTPHeaderField: "authorization") == "Bearer -token")
+        #expect(device["deviceId"] as? String == "apple-device-1")
+        #expect(device["label"] as? String == "Casey's iPad")
+        #expect(device["platform"] as? String == "apple")
+        #expect(device["createdAt"] as? String == "1970-01-01T00:01:40Z")
+        #expect(device["lastSeenAt"] as? String == "1970-01-01T00:03:20Z")
+        #expect(device["status"] as? String == "trusted")
+        #expect(snapshot.devices.first?.status == .trusted)
+    }
+
+    @Test("fetches the broker trust registry")
+    func fetchesBrokerTrustRegistry() async throws {
+        let transport = RecordingDeviceTrustTransport(responses: [
+            AppleDeviceTrustHTTPResponse(statusCode: 200, data: snapshotData(status: "trusted")),
+        ])
+        let client = AppleDeviceTrustClient(transport: transport)
+
+        let snapshot = try await client.fetchRegistry(settings: settings(authToken: "token-value"))
+
+        let request = try #require(transport.requests.first)
+
+        #expect(request.url?.absoluteString == "http://127.0.0.1:4789/trust")
+        #expect(request.httpMethod == "GET")
+        #expect(request.httpBody == nil)
+        #expect(request.value(forHTTPHeaderField: "authorization") == "Bearer token-value")
+        #expect(snapshot.devices.first?.deviceId == "apple-device-1")
+    }
+
+    @Test("revokes the local device")
+    func revokesLocalDevice() async throws {
+        let transport = RecordingDeviceTrustTransport(responses: [
+            AppleDeviceTrustHTTPResponse(statusCode: 200, data: snapshotData(status: "revoked")),
+        ])
+        let client = AppleDeviceTrustClient(transport: transport)
+
+        let snapshot = try await client.revokeDevice(
+            identity: identity,
+            settings: settings(),
+            revokedAt: Date(timeIntervalSince1970: 300)
+        )
+
+        let request = try #require(transport.requests.first)
+        let body = try requestBody(request)
+
+        #expect(request.url?.absoluteString == "http://127.0.0.1:4789/trust/devices/revoke")
+        #expect(body["deviceId"] as? String == "apple-device-1")
+        #expect(body["revokedAt"] as? String == "1970-01-01T00:05:00Z")
+        #expect(snapshot.devices.first?.status == .revoked)
+    }
+
+    @Test("requires a broker URL")
+    func requiresBrokerURL() async throws {
+        let client = AppleDeviceTrustClient(transport: RecordingDeviceTrustTransport(responses: []))
+        let settings = CockpitConnectionSettings(cockpitURL: URL(string: "http://127.0.0.1:5173")!)
+
+        await #expect(throws: AppleDeviceTrustClientError.missingBrokerURL) {
+            _ = try await client.registerDevice(identity: identity, settings: settings)
+        }
+    }
+
+    @Test("rejects failed or malformed broker responses")
+    func rejectsFailedResponses() async throws {
+        let failingClient = AppleDeviceTrustClient(transport: RecordingDeviceTrustTransport(responses: [
+            AppleDeviceTrustHTTPResponse(statusCode: 401, data: Data()),
+        ]))
+
+        await #expect(throws: AppleDeviceTrustClientError.requestFailed(401)) {
+            _ = try await failingClient.registerDevice(identity: identity, settings: settings())
+        }
+
+        let malformedClient = AppleDeviceTrustClient(transport: RecordingDeviceTrustTransport(responses: [
+            AppleDeviceTrustHTTPResponse(statusCode: 200, data: Data("{}".utf8)),
+        ]))
+
+        await #expect(throws: AppleDeviceTrustClientError.invalidResponseBody) {
+            _ = try await malformedClient.registerDevice(identity: identity, settings: settings())
+        }
+    }
+
+    private var identity: AppleDeviceIdentity {
+        AppleDeviceIdentity(
+            deviceId: "apple-device-1",
+            displayName: "Casey's iPad",
+            platform: "apple",
+            createdAt: Date(timeIntervalSince1970: 100),
+            lastSeenAt: Date(timeIntervalSince1970: 200)
+        )
+    }
+
+    private func settings(authToken: String? = nil) -> CockpitConnectionSettings {
+        CockpitConnectionSettings(
+            cockpitURL: URL(string: "http://127.0.0.1:5173")!,
+            brokerURL: URL(string: "http://127.0.0.1:4789")!,
+            brokerAuthToken: authToken
+        )
+    }
+
+    private func snapshotData(status: String) -> Data {
+        Data(
+            """
+            {
+              "version": 1,
+              "operator": null,
+              "hosts": [],
+              "devices": [
+                {
+                  "deviceId": "apple-device-1",
+                  "label": "Casey's iPad",
+                  "platform": "apple",
+                  "createdAt": "1970-01-01T00:01:40Z",
+                  "lastSeenAt": "1970-01-01T00:03:20Z",
+                  "status": "\(status)"
+                }
+              ]
+            }
+            """.utf8
+        )
+    }
+
+    private func requestBody(_ request: URLRequest) throws -> [String: Any] {
+        let data = try #require(request.httpBody)
+        return try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+}
+
+private final class RecordingDeviceTrustTransport: AppleDeviceTrustHTTPTransport, @unchecked Sendable {
+    var requests: [URLRequest] {
+        lock.withLock { capturedRequests }
+    }
+
+    private var capturedRequests: [URLRequest] = []
+    private var responses: [AppleDeviceTrustHTTPResponse]
+    private let lock = NSLock()
+
+    init(responses: [AppleDeviceTrustHTTPResponse]) {
+        self.responses = responses
+    }
+
+    func send(_ request: URLRequest) async throws -> AppleDeviceTrustHTTPResponse {
+        lock.withLock {
+            capturedRequests.append(request)
+            return responses.isEmpty ? AppleDeviceTrustHTTPResponse(statusCode: 500, data: Data()) : responses.removeFirst()
+        }
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -114,8 +114,10 @@ remain separate platform work.
 Device identity starts as a local Apple core record, also before APNs delivery.
 It stores non-secret install metadata in user defaults and reserves Keychain or
 another `SecretStore` implementation for future device-held credentials. The
-broker trust registry can later reference that device id when host, operator,
-and device trust become linked product state.
+Apple shell can register or revoke that local identity against the broker trust
+API using the stored broker URL and auth token; trust records still contain only
+device ids, labels, platform, timestamps, and trust status. APNs tokens and
+device-held secrets remain outside the trust registry.
 
 ## Protocol Principles
 

--- a/docs/every-code-integration.md
+++ b/docs/every-code-integration.md
@@ -154,6 +154,10 @@ Every Code adapter that consumes them:
   `POST /trust/devices`, and devices can be revoked with
   `POST /trust/devices/revoke`; these records must not include APNs tokens or
   device-held secrets
+- the Apple wrapper has a native device-trust client for `GET /trust`,
+  `POST /trust/devices`, and `POST /trust/devices/revoke`; it uses the stored
+  broker URL/auth token and local device identity while leaving session
+  projection and command handling in the shared cockpit
 - web clients pass broker auth with `VITE_COCKPIT_AUTH_TOKEN` when the broker is
   started with a token
 

--- a/docs/product-goals.md
+++ b/docs/product-goals.md
@@ -50,4 +50,7 @@ start by owning platform concerns such as Keychain storage, notification
 routing, notification actions, deep links, and device identity while the React
 cockpit remains the shared session and operator workflow surface. APNs
 registration and device-token upload should follow only after local
-notification routes and device identity are explicit.
+notification routes and device identity are explicit. Device trust registration
+belongs in the native shell because it combines stored broker credentials with
+the local install identity; the shared cockpit should keep owning session and
+command workflows.


### PR DESCRIPTION
## Summary

- Add an Apple core broker trust client for `GET /trust`, `POST /trust/devices`, and `POST /trust/devices/revoke`.
- Preserve broker auth-token semantics by trimming surrounding whitespace while sending the token value verbatim as `Bearer` auth.
- Add a compact native SwiftUI device-trust strip above the shared WebKit cockpit for checking, registering, and revoking the local Apple device.
- Update docs to reflect that Apple now owns the device trust registration client flow while APNs and push-token upload remain out of scope.

## Validation

- `pnpm exec prettier --check docs/architecture.md docs/every-code-integration.md docs/product-goals.md` passed.
- `git diff --check` passed.
- `pnpm apple:test` passed: 21 tests in 5 suites.
- `pnpm apple:build` passed.
- `pnpm apple:app:build` passed for `generic/platform=iOS Simulator` with `CODE_SIGNING_ALLOWED=NO`.
- `pnpm lint:dry-run` passed.
- `pnpm validate` passed: contracts 14 tests, server 52 tests, web 39 tests.
- `pnpm smoke:cockpit:web` passed at `http://127.0.0.1:57336` using broker `http://127.0.0.1:57335`.
