### PR TITLE
Harden Apple routes and keychain writes

### DIFF
--- a/apps/apple/Sources/CodeEverywhereAppleCore/CockpitDeepLink.swift
+++ b/apps/apple/Sources/CodeEverywhereAppleCore/CockpitDeepLink.swift
@@ -14,7 +14,9 @@ public struct CockpitDeepLinkParser: Sendable {
         }
 
         let pathParts = makePathParts(url: url)
-        let query = makeQueryMap(components: components)
+        guard let query = makeQueryMap(components: components) else {
+            return nil
+        }
 
         if pathParts.first == "session", let sessionId = pathParts.dropFirst().first?.nilIfBlank {
             return .session(sessionId: sessionId, pendingItemId: query["pending"]?.nilIfBlank)
@@ -46,13 +48,19 @@ public struct CockpitDeepLinkParser: Sendable {
         return parts
     }
 
-    private func makeQueryMap(components: URLComponents) -> [String: String] {
-        Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).compactMap { item in
-            guard let value = item.value else {
+    private func makeQueryMap(components: URLComponents) -> [String: String]? {
+        var values: [String: String] = [:]
+        var seenNames = Set<String>()
+        for item in components.queryItems ?? [] {
+            guard seenNames.insert(item.name).inserted else {
                 return nil
             }
-            return (item.name, value)
-        })
+            guard let value = item.value else {
+                continue
+            }
+            values[item.name] = value
+        }
+        return values
     }
 
     private func makeFragment(path: [String], query: [String: String?]) -> String {

--- a/apps/apple/Sources/CodeEverywhereAppleCore/SecretStore.swift
+++ b/apps/apple/Sources/CodeEverywhereAppleCore/SecretStore.swift
@@ -39,7 +39,16 @@ public final class KeychainSecretStore: SecretStore, @unchecked Sendable {
     }
 
     public func saveSecret(_ secret: String, account: String) throws {
-        try deleteSecret(account: account)
+        let updateStatus = SecItemUpdate(
+            baseQuery(account: account) as CFDictionary,
+            [kSecValueData as String: Data(secret.utf8)] as CFDictionary,
+        )
+        if updateStatus == errSecSuccess {
+            return
+        }
+        guard updateStatus == errSecItemNotFound else {
+            throw SecretStoreError.keychainStatus(updateStatus)
+        }
 
         var query = baseQuery(account: account)
         query[kSecValueData as String] = Data(secret.utf8)

--- a/apps/apple/Tests/CodeEverywhereAppleCoreTests/CockpitDeepLinkTests.swift
+++ b/apps/apple/Tests/CodeEverywhereAppleCoreTests/CockpitDeepLinkTests.swift
@@ -26,6 +26,11 @@ struct CockpitDeepLinkTests {
         #expect(parser.parse(try #require(URL(string: "code-everywhere://settings"))) == nil)
     }
 
+    @Test("rejects duplicate query keys without trapping")
+    func rejectsDuplicateQueryKeys() throws {
+        #expect(parser.parse(try #require(URL(string: "code-everywhere://session/session-123?pending=one&pending=two"))) == nil)
+    }
+
     @Test("creates web fragments for shared cockpit routing")
     func createsWebFragments() {
         #expect(parser.webFragment(for: .session(sessionId: "session-123", pendingItemId: "approval-9")) == "/session/session-123?pending=approval-9")

--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { getCockpitStateSurface } from "./App"
+import { getCockpitStateSurface, parseCockpitFragmentRoute } from "./App"
 
 describe("cockpit state surface", () => {
     it("keeps retained stale-event evidence visible before empty live-session state", () => {
@@ -29,5 +29,23 @@ describe("cockpit state surface", () => {
             tone: "warning",
             title: "Stale event evidence retained",
         })
+    })
+})
+
+describe("cockpit fragment routing", () => {
+    it("parses Apple deep-link fragments for sessions and pending work", () => {
+        expect(parseCockpitFragmentRoute("#/session/session-123?pending=approval-9")).toEqual({
+            sessionId: "session-123",
+            pendingItemId: "approval-9",
+        })
+        expect(parseCockpitFragmentRoute("#/pending/input-7?session=session-123")).toEqual({
+            sessionId: "session-123",
+            pendingItemId: "input-7",
+        })
+    })
+
+    it("ignores unsupported or malformed fragments", () => {
+        expect(parseCockpitFragmentRoute("")).toBeNull()
+        expect(parseCockpitFragmentRoute("#/settings")).toBeNull()
     })
 })

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -77,6 +77,11 @@ type CockpitStateSurface = {
     detail: string
 }
 
+type CockpitFragmentRoute = {
+    sessionId: string | null
+    pendingItemId: string | null
+}
+
 type TrustRegistryState = {
     snapshot: LocalTrustRegistrySnapshot | null
     status: "unavailable" | "loading" | "ready" | "error"
@@ -184,8 +189,9 @@ const attentionIcon: Record<OperatorAttentionKind, IconComponent> = {
 export const App = () => {
     const cockpitView = useCockpitView()
     const cockpit = cockpitView.fixture
-    const [activeSessionId, setActiveSessionId] = useState(selectedSessionId)
-    const [activePendingItemId, setActivePendingItemId] = useState<string | null>(null)
+    const initialRoute = getCurrentCockpitFragmentRoute()
+    const [activeSessionId, setActiveSessionId] = useState(initialRoute?.sessionId ?? selectedSessionId)
+    const [activePendingItemId, setActivePendingItemId] = useState<string | null>(initialRoute?.pendingItemId ?? null)
     const [replyDrafts, setReplyDrafts] = useState<DraftMap>({})
     const [inputAnswerDrafts, setInputAnswerDrafts] = useState<DraftMap>({})
     const [commandLog, setCommandLog] = useState("No command sent yet")
@@ -218,6 +224,24 @@ export const App = () => {
     const reply = getDraftValue(replyDrafts, activeSession?.sessionId)
     const inputAnswerValues = getRequestedInputAnswerValues(inputAnswerDrafts, activeInput)
     const inputNote = getRequestedInputNoteValue(inputAnswerDrafts, activeInput)
+
+    useEffect(() => {
+        const handleHashChange = () => {
+            const route = getCurrentCockpitFragmentRoute()
+            if (route === null) {
+                return
+            }
+            if (route.sessionId !== null) {
+                setActiveSessionId(route.sessionId)
+            }
+            setActivePendingItemId(route.pendingItemId)
+        }
+
+        window.addEventListener("hashchange", handleHashChange)
+        return () => {
+            window.removeEventListener("hashchange", handleHashChange)
+        }
+    }, [])
 
     useEffect(() => {
         if (!canManageTrust(cockpitView.transport)) {
@@ -1245,6 +1269,59 @@ const emptySessionDetailCopy = (transport: CockpitTransportStatus): string => {
             return transport.error === null
                 ? "The cockpit is showing the last known snapshot because the local broker is unavailable."
                 : `The cockpit is showing the last known snapshot because the local broker is unavailable: ${transport.error}`
+    }
+}
+
+export const parseCockpitFragmentRoute = (hash: string): CockpitFragmentRoute | null => {
+    const fragment = hash.startsWith("#") ? hash.slice(1) : hash
+    if (fragment.trim() === "") {
+        return null
+    }
+
+    let url: URL
+    try {
+        url = new URL(
+            fragment.startsWith("/") ? `http://code-everywhere.local${fragment}` : `http://code-everywhere.local/${fragment}`,
+        )
+    } catch {
+        return null
+    }
+
+    const pathParts = url.pathname
+        .split("/")
+        .filter((part) => part !== "")
+        .map((part) => decodePathPart(part))
+
+    if (pathParts[0] === "session" && pathParts[1] !== undefined && pathParts[1].trim() !== "") {
+        return {
+            sessionId: pathParts[1],
+            pendingItemId: normalizeRouteValue(url.searchParams.get("pending")),
+        }
+    }
+
+    if (pathParts[0] === "pending" && pathParts[1] !== undefined && pathParts[1].trim() !== "") {
+        return {
+            sessionId: normalizeRouteValue(url.searchParams.get("session")),
+            pendingItemId: pathParts[1],
+        }
+    }
+
+    return null
+}
+
+const getCurrentCockpitFragmentRoute = (): CockpitFragmentRoute | null =>
+    typeof window === "undefined" ? null : parseCockpitFragmentRoute(window.location.hash)
+
+const normalizeRouteValue = (value: string | null): string | null => {
+    const normalized = value?.trim() ?? ""
+    return normalized === "" ? null : normalized
+}
+
+const decodePathPart = (value: string): string => {
+    try {
+        return decodeURIComponent(value)
+    } catch {
+        return value
     }
 }
 


### PR DESCRIPTION
## Summary

- Consume Apple-generated cockpit fragments in the shared web cockpit so `#/session/...` and `#/pending/...` route to the intended session/pending item.
- Reject duplicate Apple deep-link query keys without trapping.
- Preserve an existing Keychain token when saving a replacement fails by updating in place before falling back to insert.

## Validation

- `pnpm apple:test` passed: 22 tests in 5 suites.
- `pnpm --filter @code-everywhere/web test -- App.test.ts` passed: 41 web tests.
- `pnpm apple:build` passed.
- `pnpm apple:app:build` passed for `generic/platform=iOS Simulator` with `CODE_SIGNING_ALLOWED=NO`.
- `pnpm lint:dry-run` passed.
- `pnpm validate` passed: contracts 14 tests, server 52 tests, web 41 tests.
- `pnpm smoke:cockpit:web` passed at `http://127.0.0.1:61707` using broker `http://127.0.0.1:61706`.
