### PR TITLE
Add Apple local notification readiness

### DIFF
--- a/apps/apple/Sources/CodeEverywhereAppleCore/CockpitNotificationCenter.swift
+++ b/apps/apple/Sources/CodeEverywhereAppleCore/CockpitNotificationCenter.swift
@@ -1,0 +1,147 @@
+import Foundation
+@preconcurrency import UserNotifications
+
+public enum CockpitNotificationAuthorizationState: String, Equatable, Sendable {
+    case notDetermined
+    case denied
+    case authorized
+    case provisional
+    case ephemeral
+    case unknown
+}
+
+public struct CockpitNotificationPermissionState: Equatable, Sendable {
+    public var authorization: CockpitNotificationAuthorizationState
+
+    public init(authorization: CockpitNotificationAuthorizationState) {
+        self.authorization = authorization
+    }
+
+    public var canScheduleNotifications: Bool {
+        authorization == .authorized || authorization == .provisional || authorization == .ephemeral
+    }
+}
+
+public protocol CockpitNotificationPermissionProviding: Sendable {
+    func currentPermissionState() async -> CockpitNotificationPermissionState
+    func requestPermission() async throws -> CockpitNotificationPermissionState
+}
+
+public protocol CockpitLocalNotificationScheduling: Sendable {
+    func schedule(_ notification: CockpitLocalNotification) async throws
+    func cancelNotification(id: String)
+}
+
+public struct CockpitLocalNotification: Equatable, Sendable {
+    public var id: String
+    public var title: String
+    public var body: String
+    public var route: CockpitNotificationRoute
+    public var userInfo: [String: String]
+
+    public init(id: String, title: String, body: String, route: CockpitNotificationRoute, userInfo: [String: String]) {
+        self.id = id
+        self.title = title
+        self.body = body
+        self.route = route
+        self.userInfo = userInfo
+    }
+}
+
+public struct CockpitLocalNotificationFactory: Sendable {
+    private let router: CockpitNotificationRouter
+
+    public init(router: CockpitNotificationRouter = CockpitNotificationRouter()) {
+        self.router = router
+    }
+
+    public func pendingWorkNotification(
+        pendingItemId: String,
+        sessionId: String,
+        title: String = "Code Everywhere needs attention",
+        body: String = "A session has pending work."
+    ) -> CockpitLocalNotification? {
+        guard let pendingItemId = pendingItemId.nilIfBlank,
+              let sessionId = sessionId.nilIfBlank
+        else {
+            return nil
+        }
+
+        let route = CockpitNotificationRoute.pendingItem(pendingItemId: pendingItemId, sessionId: sessionId)
+        return CockpitLocalNotification(
+            id: "code-everywhere.pending.\(pendingItemId)",
+            title: title,
+            body: body,
+            route: route,
+            userInfo: router.userInfo(for: route)
+        )
+    }
+}
+
+public struct UserNotificationPermissionProvider: CockpitNotificationPermissionProviding, @unchecked Sendable {
+    private let center: UNUserNotificationCenter
+
+    public init(center: UNUserNotificationCenter = .current()) {
+        self.center = center
+    }
+
+    public func currentPermissionState() async -> CockpitNotificationPermissionState {
+        await withCheckedContinuation { continuation in
+            center.getNotificationSettings { settings in
+                continuation.resume(returning: CockpitNotificationPermissionState(settings: settings))
+            }
+        }
+    }
+
+    public func requestPermission() async throws -> CockpitNotificationPermissionState {
+        _ = try await center.requestAuthorization(options: [.alert, .badge, .sound])
+        return await currentPermissionState()
+    }
+}
+
+public struct UserNotificationScheduler: CockpitLocalNotificationScheduling, @unchecked Sendable {
+    private let center: UNUserNotificationCenter
+
+    public init(center: UNUserNotificationCenter = .current()) {
+        self.center = center
+    }
+
+    public func schedule(_ notification: CockpitLocalNotification) async throws {
+        let content = UNMutableNotificationContent()
+        content.title = notification.title
+        content.body = notification.body
+        content.userInfo = notification.userInfo
+
+        let request = UNNotificationRequest(identifier: notification.id, content: content, trigger: nil)
+        try await center.add(request)
+    }
+
+    public func cancelNotification(id: String) {
+        center.removePendingNotificationRequests(withIdentifiers: [id])
+    }
+}
+
+extension CockpitNotificationPermissionState {
+    init(settings: UNNotificationSettings) {
+        self.init(authorization: CockpitNotificationAuthorizationState(settings.authorizationStatus))
+    }
+}
+
+extension CockpitNotificationAuthorizationState {
+    init(_ status: UNAuthorizationStatus) {
+        switch status {
+        case .notDetermined:
+            self = .notDetermined
+        case .denied:
+            self = .denied
+        case .authorized:
+            self = .authorized
+        case .provisional:
+            self = .provisional
+        case .ephemeral:
+            self = .ephemeral
+        @unknown default:
+            self = .unknown
+        }
+    }
+}

--- a/apps/apple/Sources/CodeEverywhereAppleUI/AppleNotificationReadinessPanel.swift
+++ b/apps/apple/Sources/CodeEverywhereAppleUI/AppleNotificationReadinessPanel.swift
@@ -1,0 +1,164 @@
+import CodeEverywhereAppleCore
+import SwiftUI
+
+public struct AppleNotificationReadinessPanel: View {
+    private let permissionProvider: any CockpitNotificationPermissionProviding
+
+    @State private var state = AppleNotificationReadinessPanelState.checking
+
+    public init(permissionProvider: any CockpitNotificationPermissionProviding = UserNotificationPermissionProvider()) {
+        self.permissionProvider = permissionProvider
+    }
+
+    public var body: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 12) {
+                statusLabel
+                Spacer(minLength: 8)
+                actionControls
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                statusLabel
+                actionControls
+            }
+        }
+        .buttonStyle(.bordered)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Color.secondary.opacity(0.05))
+        .task {
+            await refreshPermissionState()
+        }
+    }
+
+    private var statusLabel: some View {
+        Label {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(state.title)
+                    .font(.caption.weight(.semibold))
+                Text(state.detail)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        } icon: {
+            Image(systemName: state.systemImage)
+                .foregroundStyle(state.tint)
+        }
+        .labelStyle(.titleAndIcon)
+    }
+
+    private var actionControls: some View {
+        HStack(spacing: 8) {
+            if state.isWorking {
+                ProgressView()
+                    .controlSize(.small)
+            }
+            Button {
+                Task { await requestPermission() }
+            } label: {
+                Label("Enable", systemImage: "bell.badge")
+            }
+            .disabled(!state.canRequestPermission)
+        }
+    }
+
+    @MainActor
+    private func refreshPermissionState() async {
+        state = .checking
+        state = .permission(await permissionProvider.currentPermissionState())
+    }
+
+    @MainActor
+    private func requestPermission() async {
+        state = .requesting
+        do {
+            state = .permission(try await permissionProvider.requestPermission())
+        } catch {
+            state = .failed
+        }
+    }
+}
+
+private enum AppleNotificationReadinessPanelState: Equatable {
+    case checking
+    case requesting
+    case permission(CockpitNotificationPermissionState)
+    case failed
+
+    var title: String {
+        switch self {
+        case .checking:
+            return "Checking notifications"
+        case .requesting:
+            return "Requesting notifications"
+        case let .permission(permission):
+            return permission.canScheduleNotifications ? "Notifications ready" : "Notifications not enabled"
+        case .failed:
+            return "Notifications unavailable"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .checking:
+            return "Reading local notification state"
+        case .requesting:
+            return "Waiting for system permission"
+        case let .permission(permission):
+            switch permission.authorization {
+            case .notDetermined:
+                return "Permission has not been requested"
+            case .denied:
+                return "Enable notifications in Settings"
+            case .authorized:
+                return "Local pending-work notifications can be scheduled"
+            case .provisional:
+                return "Quiet local notifications can be scheduled"
+            case .ephemeral:
+                return "Temporary notification permission is active"
+            case .unknown:
+                return "System notification state is unknown"
+            }
+        case .failed:
+            return "Unable to read notification permission"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .checking, .requesting:
+            return "arrow.triangle.2.circlepath"
+        case let .permission(permission):
+            return permission.canScheduleNotifications ? "bell.badge" : "bell.slash"
+        case .failed:
+            return "exclamationmark.triangle"
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .checking, .requesting:
+            return .secondary
+        case let .permission(permission):
+            return permission.canScheduleNotifications ? .green : .orange
+        case .failed:
+            return .red
+        }
+    }
+
+    var isWorking: Bool {
+        self == .checking || self == .requesting
+    }
+
+    var canRequestPermission: Bool {
+        switch self {
+        case .permission(let permission):
+            return permission.authorization == .notDetermined
+        case .failed:
+            return true
+        case .checking, .requesting:
+            return false
+        }
+    }
+}

--- a/apps/apple/Sources/CodeEverywhereAppleUI/CockpitWebShell.swift
+++ b/apps/apple/Sources/CodeEverywhereAppleUI/CockpitWebShell.swift
@@ -14,6 +14,7 @@ public struct CockpitWebShell: View {
     public var body: some View {
         VStack(spacing: 0) {
             AppleDeviceTrustRegistrationPanel(settings: settings)
+            AppleNotificationReadinessPanel()
             Divider()
             CockpitWebView(url: shellURL)
         }

--- a/apps/apple/Tests/CodeEverywhereAppleCoreTests/CockpitNotificationCenterTests.swift
+++ b/apps/apple/Tests/CodeEverywhereAppleCoreTests/CockpitNotificationCenterTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Testing
+
+@testable import CodeEverywhereAppleCore
+
+@Suite("Cockpit notification center")
+struct CockpitNotificationCenterTests {
+    @Test("models schedulable permission states")
+    func modelsSchedulablePermissionStates() {
+        #expect(CockpitNotificationPermissionState(authorization: .notDetermined).canScheduleNotifications == false)
+        #expect(CockpitNotificationPermissionState(authorization: .denied).canScheduleNotifications == false)
+        #expect(CockpitNotificationPermissionState(authorization: .authorized).canScheduleNotifications)
+        #expect(CockpitNotificationPermissionState(authorization: .provisional).canScheduleNotifications)
+        #expect(CockpitNotificationPermissionState(authorization: .ephemeral).canScheduleNotifications)
+    }
+
+    @Test("creates local pending-work notifications with route user info")
+    func createsPendingWorkNotifications() throws {
+        let notification = try #require(CockpitLocalNotificationFactory().pendingWorkNotification(
+            pendingItemId: "approval-9",
+            sessionId: "session-123",
+            title: "Approval needed",
+            body: "Install dependencies?"
+        ))
+
+        #expect(notification.id == "code-everywhere.pending.approval-9")
+        #expect(notification.title == "Approval needed")
+        #expect(notification.body == "Install dependencies?")
+        #expect(notification.route == .pendingItem(pendingItemId: "approval-9", sessionId: "session-123"))
+        #expect(notification.userInfo == [
+            "codeEverywhere.routeURL": "code-everywhere://pending/approval-9?session=session-123",
+        ])
+    }
+
+    @Test("rejects empty pending-work identifiers")
+    func rejectsEmptyPendingWorkIdentifiers() {
+        let factory = CockpitLocalNotificationFactory()
+
+        #expect(factory.pendingWorkNotification(pendingItemId: " ", sessionId: "session-123") == nil)
+        #expect(factory.pendingWorkNotification(pendingItemId: "approval-9", sessionId: " ") == nil)
+    }
+
+    @Test("schedules and cancels through the abstraction")
+    func schedulesAndCancelsThroughAbstraction() async throws {
+        let scheduler = RecordingNotificationScheduler()
+        let notification = try #require(CockpitLocalNotificationFactory().pendingWorkNotification(
+            pendingItemId: "input-7",
+            sessionId: "session-123"
+        ))
+
+        try await scheduler.schedule(notification)
+        scheduler.cancelNotification(id: notification.id)
+
+        #expect(scheduler.scheduled == [notification])
+        #expect(scheduler.cancelledIds == ["code-everywhere.pending.input-7"])
+    }
+}
+
+private final class RecordingNotificationScheduler: CockpitLocalNotificationScheduling, @unchecked Sendable {
+    private let lock = NSLock()
+    private var recordedScheduled: [CockpitLocalNotification] = []
+    private var recordedCancelledIds: [String] = []
+
+    var scheduled: [CockpitLocalNotification] {
+        lock.withLock { recordedScheduled }
+    }
+
+    var cancelledIds: [String] {
+        lock.withLock { recordedCancelledIds }
+    }
+
+    func schedule(_ notification: CockpitLocalNotification) async throws {
+        lock.withLock {
+            recordedScheduled.append(notification)
+        }
+    }
+
+    func cancelNotification(id: String) {
+        lock.withLock {
+            recordedCancelledIds.append(id)
+        }
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,8 +108,10 @@ Keychain-backed token storage, and deep-link parsing.
 Notification routing starts in Apple core as route metadata, not APNs delivery.
 Native notification payloads should carry a `code-everywhere://` route URL that
 round-trips through the same session and pending-item parser used by the app
-shell. APNs registration, device-token upload, and notification permission UX
-remain separate platform work.
+shell. Local notification readiness is modeled with native permission state and
+a scheduling abstraction for pending work, but APNs registration,
+device-token upload, hosted delivery, and production notification actions remain
+separate platform work.
 
 Device identity starts as a local Apple core record, also before APNs delivery.
 It stores non-secret install metadata in user defaults and reserves Keychain or

--- a/docs/product-goals.md
+++ b/docs/product-goals.md
@@ -50,7 +50,7 @@ start by owning platform concerns such as Keychain storage, notification
 routing, notification actions, deep links, and device identity while the React
 cockpit remains the shared session and operator workflow surface. APNs
 registration and device-token upload should follow only after local
-notification routes and device identity are explicit. Device trust registration
-belongs in the native shell because it combines stored broker credentials with
-the local install identity; the shared cockpit should keep owning session and
-command workflows.
+notification routes, local notification permission state, scheduling seams, and
+device identity are explicit. Device trust registration belongs in the native
+shell because it combines stored broker credentials with the local install
+identity; the shared cockpit should keep owning session and command workflows.


### PR DESCRIPTION
## Summary

- Add Apple notification permission-state modeling and local notification scheduling protocols.
- Add UserNotifications-backed permission/scheduler adapters while keeping APNs and push-token upload out of scope.
- Add a pending-work local notification factory that reuses `CockpitNotificationRoute` userInfo/deep-link metadata.
- Add a compact native notification-readiness strip above the shared WebKit cockpit that reads permission state and requests permission only when the operator presses Enable.
- Document the local-notification-readiness boundary.

## Validation

- `pnpm exec prettier --check docs/architecture.md docs/product-goals.md` passed.
- `git diff --check` passed.
- `pnpm apple:test` passed: 26 tests in 6 suites.
- `pnpm apple:build` passed.
- `pnpm apple:app:build` passed for `generic/platform=iOS Simulator` with `CODE_SIGNING_ALLOWED=NO`.
- `pnpm lint:dry-run` passed.
- `pnpm validate` passed: contracts 14 tests, server 52 tests, web 41 tests.
- `pnpm smoke:cockpit:web` passed at `http://127.0.0.1:55827` using broker `http://127.0.0.1:55826`.
