### PR TITLE
Fix Apple notification cancellation edge cases

### DIFF
--- a/apps/apple/Sources/CodeEverywhereAppleCore/CockpitNotificationCenter.swift
+++ b/apps/apple/Sources/CodeEverywhereAppleCore/CockpitNotificationCenter.swift
@@ -57,24 +57,40 @@ public struct CockpitLocalNotificationFactory: Sendable {
 
     public func pendingWorkNotification(
         pendingItemId: String,
-        sessionId: String,
+        sessionId: String?,
         title: String = "Code Everywhere needs attention",
         body: String = "A session has pending work."
     ) -> CockpitLocalNotification? {
-        guard let pendingItemId = pendingItemId.nilIfBlank,
-              let sessionId = sessionId.nilIfBlank
-        else {
+        guard let pendingItemId = pendingItemId.nilIfBlank else {
             return nil
         }
 
+        let sessionId = sessionId?.nilIfBlank
         let route = CockpitNotificationRoute.pendingItem(pendingItemId: pendingItemId, sessionId: sessionId)
         return CockpitLocalNotification(
-            id: "code-everywhere.pending.\(pendingItemId)",
+            id: Self.pendingWorkNotificationId(pendingItemId: pendingItemId, sessionId: sessionId),
             title: title,
             body: body,
             route: route,
             userInfo: router.userInfo(for: route)
         )
+    }
+
+    private static func pendingWorkNotificationId(pendingItemId: String, sessionId: String?) -> String {
+        let scopedId = [sessionId, pendingItemId]
+            .compactMap { $0 }
+            .map(notificationIdentifierComponent)
+            .joined(separator: ".")
+        return "code-everywhere.pending.\(scopedId)"
+    }
+
+    private static func notificationIdentifierComponent(_ value: String) -> String {
+        value
+            .unicodeScalars
+            .map { scalar in
+                CharacterSet.alphanumerics.contains(scalar) || scalar == "-" || scalar == "_" ? String(scalar) : "-"
+            }
+            .joined()
     }
 }
 
@@ -118,6 +134,7 @@ public struct UserNotificationScheduler: CockpitLocalNotificationScheduling, @un
 
     public func cancelNotification(id: String) {
         center.removePendingNotificationRequests(withIdentifiers: [id])
+        center.removeDeliveredNotifications(withIdentifiers: [id])
     }
 }
 

--- a/apps/apple/Sources/CodeEverywhereAppleUI/AppleNotificationReadinessPanel.swift
+++ b/apps/apple/Sources/CodeEverywhereAppleUI/AppleNotificationReadinessPanel.swift
@@ -1,10 +1,17 @@
 import CodeEverywhereAppleCore
 import SwiftUI
+#if os(iOS)
+    import UIKit
+#endif
 
 public struct AppleNotificationReadinessPanel: View {
     private let permissionProvider: any CockpitNotificationPermissionProviding
 
+    @Environment(\.openURL) private var openURL
+    @Environment(\.scenePhase) private var scenePhase
+
     @State private var state = AppleNotificationReadinessPanelState.checking
+    @State private var permissionRequestGeneration = 0
 
     public init(permissionProvider: any CockpitNotificationPermissionProviding = UserNotificationPermissionProvider()) {
         self.permissionProvider = permissionProvider
@@ -29,6 +36,10 @@ public struct AppleNotificationReadinessPanel: View {
         .background(Color.secondary.opacity(0.05))
         .task {
             await refreshPermissionState()
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            guard newPhase == .active else { return }
+            Task { await refreshPermissionState() }
         }
     }
 
@@ -55,28 +66,57 @@ public struct AppleNotificationReadinessPanel: View {
                     .controlSize(.small)
             }
             Button {
-                Task { await requestPermission() }
+                Task { await performPrimaryAction() }
             } label: {
-                Label("Enable", systemImage: "bell.badge")
+                Label(state.actionTitle, systemImage: state.actionSystemImage)
             }
-            .disabled(!state.canRequestPermission)
+            .disabled(!state.canPerformPrimaryAction)
         }
     }
 
     @MainActor
     private func refreshPermissionState() async {
+        let generation = permissionRequestGeneration
         state = .checking
-        state = .permission(await permissionProvider.currentPermissionState())
+        let permission = await permissionProvider.currentPermissionState()
+        guard generation == permissionRequestGeneration else { return }
+        state = .permission(permission)
     }
 
     @MainActor
     private func requestPermission() async {
+        permissionRequestGeneration += 1
         state = .requesting
         do {
             state = .permission(try await permissionProvider.requestPermission())
         } catch {
             state = .failed
         }
+    }
+
+    @MainActor
+    private func performPrimaryAction() async {
+        if state.shouldOpenSettings {
+            openNotificationSettings()
+            return
+        }
+
+        await requestPermission()
+    }
+
+    private func openNotificationSettings() {
+        guard let url = URL(string: Self.notificationSettingsURLString) else { return }
+        openURL(url)
+    }
+
+    private static var notificationSettingsURLString: String {
+        #if os(iOS)
+            UIApplication.openSettingsURLString
+        #elseif os(macOS)
+            "x-apple.systempreferences:com.apple.preference.notifications"
+        #else
+            ""
+        #endif
     }
 }
 
@@ -151,14 +191,27 @@ private enum AppleNotificationReadinessPanelState: Equatable {
         self == .checking || self == .requesting
     }
 
-    var canRequestPermission: Bool {
+    var canPerformPrimaryAction: Bool {
         switch self {
         case .permission(let permission):
-            return permission.authorization == .notDetermined
+            return permission.authorization == .notDetermined || permission.authorization == .denied
         case .failed:
             return true
         case .checking, .requesting:
             return false
         }
+    }
+
+    var shouldOpenSettings: Bool {
+        guard case let .permission(permission) = self else { return false }
+        return permission.authorization == .denied
+    }
+
+    var actionTitle: String {
+        shouldOpenSettings ? "Settings" : "Enable"
+    }
+
+    var actionSystemImage: String {
+        shouldOpenSettings ? "gearshape" : "bell.badge"
     }
 }

--- a/apps/apple/Tests/CodeEverywhereAppleCoreTests/CockpitNotificationCenterTests.swift
+++ b/apps/apple/Tests/CodeEverywhereAppleCoreTests/CockpitNotificationCenterTests.swift
@@ -23,7 +23,7 @@ struct CockpitNotificationCenterTests {
             body: "Install dependencies?"
         ))
 
-        #expect(notification.id == "code-everywhere.pending.approval-9")
+        #expect(notification.id == "code-everywhere.pending.session-123.approval-9")
         #expect(notification.title == "Approval needed")
         #expect(notification.body == "Install dependencies?")
         #expect(notification.route == .pendingItem(pendingItemId: "approval-9", sessionId: "session-123"))
@@ -32,12 +32,37 @@ struct CockpitNotificationCenterTests {
         ])
     }
 
+    @Test("scopes pending-work notification ids by session")
+    func scopesPendingWorkNotificationIdsBySession() throws {
+        let factory = CockpitLocalNotificationFactory()
+        let first = try #require(factory.pendingWorkNotification(pendingItemId: "approval-9", sessionId: "session-123"))
+        let second = try #require(factory.pendingWorkNotification(pendingItemId: "approval-9", sessionId: "session-456"))
+
+        #expect(first.id == "code-everywhere.pending.session-123.approval-9")
+        #expect(second.id == "code-everywhere.pending.session-456.approval-9")
+        #expect(first.id != second.id)
+    }
+
+    @Test("creates sessionless pending-work notifications")
+    func createsSessionlessPendingWorkNotifications() throws {
+        let notification = try #require(CockpitLocalNotificationFactory().pendingWorkNotification(
+            pendingItemId: "approval-9",
+            sessionId: nil
+        ))
+
+        #expect(notification.id == "code-everywhere.pending.approval-9")
+        #expect(notification.route == .pendingItem(pendingItemId: "approval-9", sessionId: nil))
+        #expect(notification.userInfo == [
+            "codeEverywhere.routeURL": "code-everywhere://pending/approval-9",
+        ])
+    }
+
     @Test("rejects empty pending-work identifiers")
     func rejectsEmptyPendingWorkIdentifiers() {
         let factory = CockpitLocalNotificationFactory()
 
         #expect(factory.pendingWorkNotification(pendingItemId: " ", sessionId: "session-123") == nil)
-        #expect(factory.pendingWorkNotification(pendingItemId: "approval-9", sessionId: " ") == nil)
+        #expect(factory.pendingWorkNotification(pendingItemId: "approval-9", sessionId: " ") != nil)
     }
 
     @Test("schedules and cancels through the abstraction")
@@ -52,7 +77,7 @@ struct CockpitNotificationCenterTests {
         scheduler.cancelNotification(id: notification.id)
 
         #expect(scheduler.scheduled == [notification])
-        #expect(scheduler.cancelledIds == ["code-everywhere.pending.input-7"])
+        #expect(scheduler.cancelledIds == ["code-everywhere.pending.session-123.input-7"])
     }
 }
 


### PR DESCRIPTION
## Summary\n- scope pending-work local notification IDs by session while preserving sessionless pending-item routes\n- remove delivered notifications when canceling a pending-work notification\n- refresh notification readiness on scene activation, ignore stale async refreshes, and route denied permission to Settings\n\n## Validation\n- pnpm apple:test\n- pnpm lint:dry-run && pnpm validate && pnpm smoke:cockpit:web && pnpm apple:build && pnpm apple:test && pnpm apple:app:build\n- CODE_EVERYWHERE_CODE_BINARY=/Users/cbusillo/Developer/code/code-rs/target/debug/code pnpm smoke:cockpit:real-tui\n- CODE_EVERYWHERE_CODE_BINARY=/Users/cbusillo/Developer/code/code-rs/target/debug/code pnpm smoke:cockpit:real-tui:pending-work\n- WebStorm targeted inspection on changed Swift files: clean\n