### PR TITLE
Schedule Apple pending-work notifications from snapshots

### DIFF
--- a/apps/apple/Sources/CodeEverywhereAppleCore/CockpitPendingWorkNotificationSync.swift
+++ b/apps/apple/Sources/CodeEverywhereAppleCore/CockpitPendingWorkNotificationSync.swift
@@ -1,0 +1,208 @@
+import Foundation
+
+public struct CockpitSnapshotHTTPResponse: Equatable, Sendable {
+    public var statusCode: Int
+    public var data: Data
+
+    public init(statusCode: Int, data: Data) {
+        self.statusCode = statusCode
+        self.data = data
+    }
+}
+
+public protocol CockpitSnapshotHTTPTransport: Sendable {
+    func send(_ request: URLRequest) async throws -> CockpitSnapshotHTTPResponse
+}
+
+public struct URLSessionCockpitSnapshotHTTPTransport: CockpitSnapshotHTTPTransport, @unchecked Sendable {
+    private let session: URLSession
+
+    public init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    public func send(_ request: URLRequest) async throws -> CockpitSnapshotHTTPResponse {
+        let (data, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw CockpitPendingWorkNotificationSyncError.invalidHTTPResponse
+        }
+
+        return CockpitSnapshotHTTPResponse(statusCode: httpResponse.statusCode, data: data)
+    }
+}
+
+public enum CockpitPendingWorkNotificationSyncError: Error, Equatable {
+    case missingBrokerURL
+    case invalidHTTPResponse
+    case requestFailed(Int)
+    case invalidSnapshot
+}
+
+public struct CockpitPendingWorkNotificationCandidate: Equatable, Sendable {
+    public var pendingItemId: String
+    public var sessionId: String?
+    public var title: String
+    public var body: String
+
+    public init(pendingItemId: String, sessionId: String?, title: String, body: String) {
+        self.pendingItemId = pendingItemId
+        self.sessionId = sessionId?.nilIfBlank
+        self.title = title
+        self.body = body
+    }
+}
+
+public struct CockpitPendingWorkSnapshotClient: Sendable {
+    private let transport: any CockpitSnapshotHTTPTransport
+
+    public init(transport: any CockpitSnapshotHTTPTransport = URLSessionCockpitSnapshotHTTPTransport()) {
+        self.transport = transport
+    }
+
+    public func fetchPendingWork(settings: CockpitConnectionSettings) async throws -> [CockpitPendingWorkNotificationCandidate] {
+        guard let brokerURL = settings.brokerURL else {
+            throw CockpitPendingWorkNotificationSyncError.missingBrokerURL
+        }
+
+        var request = URLRequest(url: brokerURL.appendingPathComponent("snapshot"))
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "accept")
+        if let token = settings.brokerAuthToken?.nilIfBlank {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "authorization")
+        }
+
+        let response = try await transport.send(request)
+        guard (200..<300).contains(response.statusCode) else {
+            throw CockpitPendingWorkNotificationSyncError.requestFailed(response.statusCode)
+        }
+
+        let decoder = JSONDecoder()
+        guard let snapshot = try? decoder.decode(CockpitPendingWorkSnapshot.self, from: response.data) else {
+            throw CockpitPendingWorkNotificationSyncError.invalidSnapshot
+        }
+
+        return snapshot.pendingWorkCandidates()
+    }
+}
+
+public actor CockpitPendingWorkNotificationSynchronizer {
+    private let snapshotClient: CockpitPendingWorkSnapshotClient
+    private let permissionProvider: any CockpitNotificationPermissionProviding
+    private let scheduler: any CockpitLocalNotificationScheduling
+    private let factory: CockpitLocalNotificationFactory
+    private var scheduledNotificationIds: Set<String> = []
+
+    public init(
+        snapshotClient: CockpitPendingWorkSnapshotClient = CockpitPendingWorkSnapshotClient(),
+        permissionProvider: any CockpitNotificationPermissionProviding = UserNotificationPermissionProvider(),
+        scheduler: any CockpitLocalNotificationScheduling = UserNotificationScheduler(),
+        factory: CockpitLocalNotificationFactory = CockpitLocalNotificationFactory()
+    ) {
+        self.snapshotClient = snapshotClient
+        self.permissionProvider = permissionProvider
+        self.scheduler = scheduler
+        self.factory = factory
+    }
+
+    public func sync(settings: CockpitConnectionSettings) async throws {
+        guard settings.brokerURL != nil else {
+            cancelNotifications(ids: scheduledNotificationIds)
+            scheduledNotificationIds = []
+            return
+        }
+
+        let permission = await permissionProvider.currentPermissionState()
+        guard permission.canScheduleNotifications else {
+            cancelNotifications(ids: scheduledNotificationIds)
+            scheduledNotificationIds = []
+            return
+        }
+
+        let candidates = try await snapshotClient.fetchPendingWork(settings: settings)
+        let notifications = candidates.compactMap { candidate in
+            factory.pendingWorkNotification(
+                pendingItemId: candidate.pendingItemId,
+                sessionId: candidate.sessionId,
+                title: candidate.title,
+                body: candidate.body
+            )
+        }
+        let nextNotificationIds = Set(notifications.map(\.id))
+
+        cancelNotifications(ids: scheduledNotificationIds.subtracting(nextNotificationIds))
+
+        for notification in notifications where !scheduledNotificationIds.contains(notification.id) {
+            try await scheduler.schedule(notification)
+        }
+
+        scheduledNotificationIds = nextNotificationIds
+    }
+
+    public func cancelAll() {
+        cancelNotifications(ids: scheduledNotificationIds)
+        scheduledNotificationIds = []
+    }
+
+    public func scheduledIdsForTesting() -> Set<String> {
+        scheduledNotificationIds
+    }
+
+    private func cancelNotifications(ids: Set<String>) {
+        for id in ids {
+            scheduler.cancelNotification(id: id)
+        }
+    }
+}
+
+private struct CockpitPendingWorkSnapshot: Decodable {
+    var state: CockpitPendingWorkProjectionState
+
+    func pendingWorkCandidates() -> [CockpitPendingWorkNotificationCandidate] {
+        let approvals = state.pendingApprovals.values.map { approval in
+            CockpitPendingWorkNotificationCandidate(
+                pendingItemId: approval.id,
+                sessionId: approval.sessionId,
+                title: approval.title,
+                body: approval.body
+            )
+        }
+        let inputs = state.requestedInputs.values.map { input in
+            CockpitPendingWorkNotificationCandidate(
+                pendingItemId: input.id,
+                sessionId: input.sessionId,
+                title: input.title,
+                body: input.questions.first?.prompt ?? "Every Code requested input."
+            )
+        }
+
+        return (approvals + inputs).sorted { left, right in
+            if left.sessionId == right.sessionId {
+                return left.pendingItemId < right.pendingItemId
+            }
+            return (left.sessionId ?? "") < (right.sessionId ?? "")
+        }
+    }
+}
+
+private struct CockpitPendingWorkProjectionState: Decodable {
+    var pendingApprovals: [String: CockpitPendingApprovalSnapshot]
+    var requestedInputs: [String: CockpitRequestedInputSnapshot]
+}
+
+private struct CockpitPendingApprovalSnapshot: Decodable {
+    var id: String
+    var sessionId: String
+    var title: String
+    var body: String
+}
+
+private struct CockpitRequestedInputSnapshot: Decodable {
+    var id: String
+    var sessionId: String
+    var title: String
+    var questions: [CockpitRequestedInputQuestionSnapshot]
+}
+
+private struct CockpitRequestedInputQuestionSnapshot: Decodable {
+    var prompt: String
+}

--- a/apps/apple/Sources/CodeEverywhereAppleUI/ApplePendingWorkNotificationSyncTask.swift
+++ b/apps/apple/Sources/CodeEverywhereAppleUI/ApplePendingWorkNotificationSyncTask.swift
@@ -1,0 +1,72 @@
+import CodeEverywhereAppleCore
+import SwiftUI
+
+public struct ApplePendingWorkNotificationSyncTask: View {
+    private let settings: CockpitConnectionSettings
+
+    @Environment(\.scenePhase) private var scenePhase
+    @State private var synchronizer: CockpitPendingWorkNotificationSynchronizer
+    @State private var syncTask: Task<Void, Never>?
+
+    public init(
+        settings: CockpitConnectionSettings,
+        synchronizer: CockpitPendingWorkNotificationSynchronizer = CockpitPendingWorkNotificationSynchronizer()
+    ) {
+        self.settings = settings
+        _synchronizer = State(initialValue: synchronizer)
+    }
+
+    public var body: some View {
+        Color.clear
+            .frame(width: 0, height: 0)
+            .accessibilityHidden(true)
+            .task {
+                startSyncingIfNeeded()
+            }
+            .onChange(of: scenePhase) { _, newPhase in
+                if newPhase == .active {
+                    startSyncingIfNeeded()
+                } else if newPhase == .background {
+                    stopSyncing()
+                }
+            }
+            .onChange(of: settings) { _, _ in
+                restartSyncing()
+            }
+            .onDisappear {
+                stopSyncing()
+            }
+    }
+
+    @MainActor
+    private func startSyncingIfNeeded() {
+        guard settings.brokerURL != nil else { return }
+        guard syncTask == nil else { return }
+
+        syncTask = Task {
+            while !Task.isCancelled {
+                try? await synchronizer.sync(settings: settings)
+                try? await Task.sleep(for: .seconds(15))
+            }
+        }
+    }
+
+    @MainActor
+    private func stopSyncing() {
+        syncTask?.cancel()
+        syncTask = nil
+    }
+
+    @MainActor
+    private func restartSyncing() {
+        stopSyncing()
+
+        syncTask = Task {
+            await synchronizer.cancelAll()
+            await MainActor.run {
+                syncTask = nil
+                startSyncingIfNeeded()
+            }
+        }
+    }
+}

--- a/apps/apple/Sources/CodeEverywhereAppleUI/CockpitWebShell.swift
+++ b/apps/apple/Sources/CodeEverywhereAppleUI/CockpitWebShell.swift
@@ -15,6 +15,7 @@ public struct CockpitWebShell: View {
         VStack(spacing: 0) {
             AppleDeviceTrustRegistrationPanel(settings: settings)
             AppleNotificationReadinessPanel()
+            ApplePendingWorkNotificationSyncTask(settings: settings)
             Divider()
             CockpitWebView(url: shellURL)
         }

--- a/apps/apple/Tests/CodeEverywhereAppleCoreTests/CockpitPendingWorkNotificationSyncTests.swift
+++ b/apps/apple/Tests/CodeEverywhereAppleCoreTests/CockpitPendingWorkNotificationSyncTests.swift
@@ -1,0 +1,238 @@
+import Foundation
+import Testing
+
+@testable import CodeEverywhereAppleCore
+
+@Suite("Cockpit pending-work notification sync")
+struct CockpitPendingWorkNotificationSyncTests {
+    @Test("fetches pending work from the broker snapshot")
+    func fetchesPendingWorkFromBrokerSnapshot() async throws {
+        let transport = RecordingSnapshotTransport(responses: [
+            CockpitSnapshotHTTPResponse(statusCode: 200, data: snapshotData(approvalIds: ["approval-1"], inputIds: ["input-1"])),
+        ])
+        let client = CockpitPendingWorkSnapshotClient(transport: transport)
+
+        let candidates = try await client.fetchPendingWork(settings: settings(authToken: "token-value"))
+
+        #expect(candidates == [
+            CockpitPendingWorkNotificationCandidate(
+                pendingItemId: "approval-1",
+                sessionId: "session-1",
+                title: "Approval needed",
+                body: "Run pnpm validate?"
+            ),
+            CockpitPendingWorkNotificationCandidate(
+                pendingItemId: "input-1",
+                sessionId: "session-1",
+                title: "Input needed",
+                body: "Choose the next step."
+            ),
+        ])
+        #expect(transport.requests.first?.url?.absoluteString == "http://127.0.0.1:4789/snapshot")
+        #expect(transport.requests.first?.value(forHTTPHeaderField: "authorization") == "Bearer token-value")
+    }
+
+    @Test("synchronizer schedules new pending work once")
+    func synchronizerSchedulesNewPendingWorkOnce() async throws {
+        let transport = RecordingSnapshotTransport(responses: [
+            CockpitSnapshotHTTPResponse(statusCode: 200, data: snapshotData(approvalIds: ["approval-1"])),
+            CockpitSnapshotHTTPResponse(statusCode: 200, data: snapshotData(approvalIds: ["approval-1"])),
+        ])
+        let scheduler = RecordingNotificationScheduler()
+        let synchronizer = CockpitPendingWorkNotificationSynchronizer(
+            snapshotClient: CockpitPendingWorkSnapshotClient(transport: transport),
+            permissionProvider: StaticNotificationPermissionProvider(.authorized),
+            scheduler: scheduler
+        )
+
+        try await synchronizer.sync(settings: settings())
+        try await synchronizer.sync(settings: settings())
+
+        #expect(scheduler.scheduled.map(\.id) == ["code-everywhere.pending.session-1.approval-1"])
+        #expect(scheduler.cancelledIds == [])
+        #expect(await synchronizer.scheduledIdsForTesting() == ["code-everywhere.pending.session-1.approval-1"])
+    }
+
+    @Test("synchronizer cancels resolved pending work")
+    func synchronizerCancelsResolvedPendingWork() async throws {
+        let transport = RecordingSnapshotTransport(responses: [
+            CockpitSnapshotHTTPResponse(statusCode: 200, data: snapshotData(approvalIds: ["approval-1"], inputIds: ["input-1"])),
+            CockpitSnapshotHTTPResponse(statusCode: 200, data: snapshotData(inputIds: ["input-1"])),
+        ])
+        let scheduler = RecordingNotificationScheduler()
+        let synchronizer = CockpitPendingWorkNotificationSynchronizer(
+            snapshotClient: CockpitPendingWorkSnapshotClient(transport: transport),
+            permissionProvider: StaticNotificationPermissionProvider(.authorized),
+            scheduler: scheduler
+        )
+
+        try await synchronizer.sync(settings: settings())
+        try await synchronizer.sync(settings: settings())
+
+        #expect(scheduler.scheduled.map(\.id) == [
+            "code-everywhere.pending.session-1.approval-1",
+            "code-everywhere.pending.session-1.input-1",
+        ])
+        #expect(scheduler.cancelledIds == ["code-everywhere.pending.session-1.approval-1"])
+        #expect(await synchronizer.scheduledIdsForTesting() == ["code-everywhere.pending.session-1.input-1"])
+    }
+
+    @Test("synchronizer cancels all notifications when permission is not schedulable")
+    func synchronizerCancelsAllWhenPermissionIsNotSchedulable() async throws {
+        let transport = RecordingSnapshotTransport(responses: [
+            CockpitSnapshotHTTPResponse(statusCode: 200, data: snapshotData(approvalIds: ["approval-1"])),
+        ])
+        let permissionProvider = MutableNotificationPermissionProvider(.authorized)
+        let scheduler = RecordingNotificationScheduler()
+        let synchronizer = CockpitPendingWorkNotificationSynchronizer(
+            snapshotClient: CockpitPendingWorkSnapshotClient(transport: transport),
+            permissionProvider: permissionProvider,
+            scheduler: scheduler
+        )
+
+        try await synchronizer.sync(settings: settings())
+        permissionProvider.authorization = .denied
+        try await synchronizer.sync(settings: settings())
+
+        #expect(scheduler.scheduled.map(\.id) == ["code-everywhere.pending.session-1.approval-1"])
+        #expect(scheduler.cancelledIds == ["code-everywhere.pending.session-1.approval-1"])
+        #expect(await synchronizer.scheduledIdsForTesting() == [])
+    }
+
+    @Test("synchronizer cancels all notifications when broker settings are cleared")
+    func synchronizerCancelsAllWhenBrokerSettingsAreCleared() async throws {
+        let transport = RecordingSnapshotTransport(responses: [
+            CockpitSnapshotHTTPResponse(statusCode: 200, data: snapshotData(approvalIds: ["approval-1"])),
+        ])
+        let scheduler = RecordingNotificationScheduler()
+        let synchronizer = CockpitPendingWorkNotificationSynchronizer(
+            snapshotClient: CockpitPendingWorkSnapshotClient(transport: transport),
+            permissionProvider: StaticNotificationPermissionProvider(.authorized),
+            scheduler: scheduler
+        )
+
+        try await synchronizer.sync(settings: settings())
+        try await synchronizer.sync(settings: settings(brokerURL: nil))
+
+        #expect(scheduler.scheduled.map(\.id) == ["code-everywhere.pending.session-1.approval-1"])
+        #expect(scheduler.cancelledIds == ["code-everywhere.pending.session-1.approval-1"])
+        #expect(await synchronizer.scheduledIdsForTesting() == [])
+    }
+}
+
+private final class RecordingSnapshotTransport: CockpitSnapshotHTTPTransport, @unchecked Sendable {
+    private let lock = NSLock()
+    private var responses: [CockpitSnapshotHTTPResponse]
+    private var recordedRequests: [URLRequest] = []
+
+    init(responses: [CockpitSnapshotHTTPResponse]) {
+        self.responses = responses
+    }
+
+    var requests: [URLRequest] {
+        lock.withLock { recordedRequests }
+    }
+
+    func send(_ request: URLRequest) async throws -> CockpitSnapshotHTTPResponse {
+        try lock.withLock {
+            recordedRequests.append(request)
+            guard !responses.isEmpty else {
+                throw CockpitPendingWorkNotificationSyncError.invalidSnapshot
+            }
+            return responses.removeFirst()
+        }
+    }
+}
+
+private final class RecordingNotificationScheduler: CockpitLocalNotificationScheduling, @unchecked Sendable {
+    private let lock = NSLock()
+    private var recordedScheduled: [CockpitLocalNotification] = []
+    private var recordedCancelledIds: [String] = []
+
+    var scheduled: [CockpitLocalNotification] {
+        lock.withLock { recordedScheduled }
+    }
+
+    var cancelledIds: [String] {
+        lock.withLock { recordedCancelledIds }
+    }
+
+    func schedule(_ notification: CockpitLocalNotification) async throws {
+        lock.withLock {
+            recordedScheduled.append(notification)
+        }
+    }
+
+    func cancelNotification(id: String) {
+        lock.withLock {
+            recordedCancelledIds.append(id)
+        }
+    }
+}
+
+private struct StaticNotificationPermissionProvider: CockpitNotificationPermissionProviding {
+    var authorization: CockpitNotificationAuthorizationState
+
+    init(_ authorization: CockpitNotificationAuthorizationState) {
+        self.authorization = authorization
+    }
+
+    func currentPermissionState() async -> CockpitNotificationPermissionState {
+        CockpitNotificationPermissionState(authorization: authorization)
+    }
+
+    func requestPermission() async throws -> CockpitNotificationPermissionState {
+        CockpitNotificationPermissionState(authorization: authorization)
+    }
+}
+
+private final class MutableNotificationPermissionProvider: CockpitNotificationPermissionProviding, @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedAuthorization: CockpitNotificationAuthorizationState
+
+    init(_ authorization: CockpitNotificationAuthorizationState) {
+        self.storedAuthorization = authorization
+    }
+
+    var authorization: CockpitNotificationAuthorizationState {
+        get { lock.withLock { storedAuthorization } }
+        set { lock.withLock { storedAuthorization = newValue } }
+    }
+
+    func currentPermissionState() async -> CockpitNotificationPermissionState {
+        CockpitNotificationPermissionState(authorization: authorization)
+    }
+
+    func requestPermission() async throws -> CockpitNotificationPermissionState {
+        CockpitNotificationPermissionState(authorization: authorization)
+    }
+}
+
+private func settings(brokerURL: URL? = URL(string: "http://127.0.0.1:4789")!, authToken: String? = nil) -> CockpitConnectionSettings {
+    CockpitConnectionSettings(
+        cockpitURL: URL(string: "http://127.0.0.1:5173")!,
+        brokerURL: brokerURL,
+        brokerAuthToken: authToken
+    )
+}
+
+private func snapshotData(approvalIds: [String] = [], inputIds: [String] = []) -> Data {
+    let approvals = approvalIds
+        .map { id in
+            "\"\(id)\":{\"id\":\"\(id)\",\"sessionId\":\"session-1\",\"title\":\"Approval needed\",\"body\":\"Run pnpm validate?\"}"
+        }
+        .joined(separator: ",")
+    let inputs = inputIds
+        .map { id in
+            "\"\(id)\":{\"id\":\"\(id)\",\"sessionId\":\"session-1\",\"title\":\"Input needed\",\"questions\":[{\"prompt\":\"Choose the next step.\"}]}"
+        }
+        .joined(separator: ",")
+    return Data("""
+    {
+      "state": {
+        "pendingApprovals": {\(approvals)},
+        "requestedInputs": {\(inputs)}
+      }
+    }
+    """.utf8)
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -109,7 +109,9 @@ Notification routing starts in Apple core as route metadata, not APNs delivery.
 Native notification payloads should carry a `code-everywhere://` route URL that
 round-trips through the same session and pending-item parser used by the app
 shell. Local notification readiness is modeled with native permission state and
-a scheduling abstraction for pending work, but APNs registration,
+a scheduling abstraction for pending work. The Apple shell polls the broker
+snapshot while active, derives actionable pending approval/input notifications,
+and reconciles schedule/cancel calls through that abstraction. APNs registration,
 device-token upload, hosted delivery, and production notification actions remain
 separate platform work.
 


### PR DESCRIPTION
## Summary
- poll the broker snapshot from the Apple shell while active and derive pending approval/input notification candidates
- schedule/cancel local pending-work notifications through the existing native notification abstraction
- document the local snapshot-driven notification path and add Swift regression coverage for schedule, cancel, permission, and broker-clear behavior

## Validation
- pnpm apple:test && pnpm apple:build
- pnpm lint:dry-run && pnpm validate && pnpm smoke:cockpit:web && pnpm apple:app:build && CODE_EVERYWHERE_CODE_BINARY=/Users/cbusillo/Developer/code/code-rs/target/debug/code pnpm smoke:cockpit:real-tui && CODE_EVERYWHERE_CODE_BINARY=/Users/cbusillo/Developer/code/code-rs/target/debug/code pnpm smoke:cockpit:real-tui:pending-work && git diff --check
- WebStorm targeted inspection on changed files: clean