### PR TITLE
Keep requested input visible after approval handoff

### DIFF
--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -1,6 +1,7 @@
+import type { PendingApproval, RequestedInput } from "@code-everywhere/contracts"
 import { describe, expect, it } from "vitest"
 
-import { getCockpitStateSurface, parseCockpitFragmentRoute } from "./App"
+import { getActivePendingWork, getCockpitStateSurface, parseCockpitFragmentRoute } from "./App"
 
 describe("cockpit state surface", () => {
     it("keeps retained stale-event evidence visible before empty live-session state", () => {
@@ -47,5 +48,55 @@ describe("cockpit fragment routing", () => {
     it("ignores unsupported or malformed fragments", () => {
         expect(parseCockpitFragmentRoute("")).toBeNull()
         expect(parseCockpitFragmentRoute("#/settings")).toBeNull()
+    })
+})
+
+describe("active pending work selection", () => {
+    const approval: PendingApproval = {
+        id: "approval-1",
+        sessionId: "session-1",
+        sessionEpoch: "epoch-1",
+        turnId: "turn-1",
+        title: "Approval required",
+        body: "Run command?",
+        command: "pnpm validate",
+        cwd: "/tmp/project",
+        risk: "medium",
+        requestedAt: "2026-04-29T20:00:00.000Z",
+    }
+    const requestedInput: RequestedInput = {
+        id: "input-1",
+        sessionId: "session-1",
+        sessionEpoch: "epoch-1",
+        turnId: "turn-1",
+        title: "Input requested",
+        requestedAt: "2026-04-29T20:01:00.000Z",
+        questions: [
+            {
+                id: "mode",
+                label: "Mode",
+                prompt: "Choose a mode.",
+                required: true,
+                options: [{ label: "Continue", value: "continue" }],
+            },
+        ],
+    }
+
+    it("falls back to current requested input when a selected approval has resolved", () => {
+        expect(getActivePendingWork("approval-1", [], [requestedInput])).toEqual({
+            approval: undefined,
+            requestedInput,
+        })
+    })
+
+    it("preserves an explicitly selected pending item when it is still actionable", () => {
+        expect(getActivePendingWork("approval-1", [approval], [requestedInput])).toEqual({
+            approval,
+            requestedInput: undefined,
+        })
+        expect(getActivePendingWork("input-1", [approval], [requestedInput])).toEqual({
+            approval: undefined,
+            requestedInput,
+        })
     })
 })

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -82,6 +82,11 @@ type CockpitFragmentRoute = {
     pendingItemId: string | null
 }
 
+type ActivePendingWork = {
+    approval: PendingApproval | undefined
+    requestedInput: RequestedInput | undefined
+}
+
 type TrustRegistryState = {
     snapshot: LocalTrustRegistrySnapshot | null
     status: "unavailable" | "loading" | "ready" | "error"
@@ -214,11 +219,11 @@ export const App = () => {
     const sessionInputs = cockpit.requestedInputs.filter(
         (input) => input.sessionId === activeSession?.sessionId && hasActionableRequestedInput(input),
     )
-    const selectedApproval = sessionApprovals.find((approval) => approval.id === activePendingItemId)
-    const selectedInput = sessionInputs.find((input) => input.id === activePendingItemId)
-    const activeApproval =
-        activePendingItemId === null || selectedApproval !== undefined ? (selectedApproval ?? sessionApprovals[0]) : undefined
-    const activeInput = activePendingItemId === null || selectedInput !== undefined ? (selectedInput ?? sessionInputs[0]) : undefined
+    const { approval: activeApproval, requestedInput: activeInput } = getActivePendingWork(
+        activePendingItemId,
+        sessionApprovals,
+        sessionInputs,
+    )
     const activeCommandHistory = getCommandHistoryEntries(cockpit.commands, cockpit.commandOutcomes, activeSession)
     const activeCommandOutcomeSummary = getCommandOutcomeSummary(cockpit.commands, cockpit.commandOutcomes, activeSession)
     const reply = getDraftValue(replyDrafts, activeSession?.sessionId)
@@ -1272,6 +1277,28 @@ const emptySessionDetailCopy = (transport: CockpitTransportStatus): string => {
     }
 }
 
+export const getActivePendingWork = (
+    pendingItemId: string | null,
+    approvals: PendingApproval[],
+    requestedInputs: RequestedInput[],
+): ActivePendingWork => {
+    if (pendingItemId === null) {
+        return { approval: approvals[0], requestedInput: requestedInputs[0] }
+    }
+
+    const selectedApproval = approvals.find((approval) => approval.id === pendingItemId)
+    if (selectedApproval !== undefined) {
+        return { approval: selectedApproval, requestedInput: undefined }
+    }
+
+    const selectedInput = requestedInputs.find((input) => input.id === pendingItemId)
+    if (selectedInput !== undefined) {
+        return { approval: undefined, requestedInput: selectedInput }
+    }
+
+    return { approval: approvals[0], requestedInput: requestedInputs[0] }
+}
+
 export const parseCockpitFragmentRoute = (hash: string): CockpitFragmentRoute | null => {
     const fragment = hash.startsWith("#") ? hash.slice(1) : hash
     if (fragment.trim() === "") {
@@ -1281,7 +1308,7 @@ export const parseCockpitFragmentRoute = (hash: string): CockpitFragmentRoute | 
     let url: URL
     try {
         url = new URL(
-            fragment.startsWith("/") ? `http://code-everywhere.local${fragment}` : `http://code-everywhere.local/${fragment}`,
+            fragment.startsWith("/") ? `https://code-everywhere.local${fragment}` : `https://code-everywhere.local/${fragment}`,
         )
     } catch {
         return null


### PR DESCRIPTION
## Summary
- keep the active pending-work panel pointed at current actionable work when a previously selected approval resolves
- preserve explicit pending item selection when that item is still present
- add regression coverage for approval-to-requested-input handoff
- use an HTTPS dummy base for fragment parsing to keep IDE inspections clean

## Validation
- pnpm lint:dry-run && pnpm --filter @code-everywhere/web test -- App.test.ts && pnpm smoke:cockpit:web
- pnpm lint:dry-run && pnpm validate && git diff --check
- WebStorm targeted inspection on apps/web/src/App.tsx and apps/web/src/App.test.ts: clean
- live browser proof against broker http://127.0.0.1:4789 and web http://127.0.0.1:5180: approval accepted, requested input rendered, input response accepted, pending counts cleared