### PR TITLE
Add Apple cockpit connection settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,11 @@ pnpm apple:app:build
 
 The iOS/iPadOS app target builds for the simulator with signing disabled. It
 hosts the shared cockpit in a native web view and keeps native code focused on
-platform boundaries: Keychain-backed broker tokens, future device identity, and
-deep-link routing into session or pending-work state.
+platform boundaries: editable cockpit/broker connection settings,
+Keychain-backed broker tokens, device identity and trust registration, local
+notification readiness, and deep-link routing into session or pending-work
+state. For simulator or device testing against a Mac-hosted server, configure
+the Apple shell with the Mac LAN URL rather than `localhost`.
 
 ## References
 

--- a/apps/apple/App/CodeEverywhereApp.swift
+++ b/apps/apple/App/CodeEverywhereApp.swift
@@ -4,24 +4,40 @@ import SwiftUI
 
 @main
 struct CodeEverywhereApp: App {
-    @State private var deepLinkRoute: CockpitDeepLinkRoute?
-
-    private let deepLinkParser = CockpitDeepLinkParser()
-    private let notificationRouter = CockpitNotificationRouter()
-    private let settings = CockpitConnectionSettings(
+    private static let defaultSettings = CockpitConnectionSettings(
         cockpitURL: URL(string: "http://127.0.0.1:5173")!,
         brokerURL: URL(string: "http://127.0.0.1:3000")!
     )
 
+    private let settingsStore: CockpitConnectionSettingsStore
+
+    @State private var deepLinkRoute: CockpitDeepLinkRoute?
+    @State private var settings: CockpitConnectionSettings
+
+    private let deepLinkParser = CockpitDeepLinkParser()
+    private let notificationRouter = CockpitNotificationRouter()
+
+    init() {
+        let store = CockpitConnectionSettingsStore(secrets: KeychainSecretStore())
+        settingsStore = store
+        _settings = State(initialValue: Self.initialSettings(store: store))
+    }
+
     var body: some Scene {
         WindowGroup {
             NavigationStack {
-                CockpitWebShell(settings: settings, deepLinkRoute: deepLinkRoute)
+                CockpitWebShell(settings: $settings, settingsStore: settingsStore, deepLinkRoute: deepLinkRoute)
                     .ignoresSafeArea(edges: .bottom)
             }
             .onOpenURL { url in
                 deepLinkRoute = notificationRouter.route(from: url)?.deepLinkRoute ?? deepLinkParser.parse(url)
             }
         }
+    }
+
+    private static func initialSettings(store: CockpitConnectionSettingsStore) -> CockpitConnectionSettings {
+        (try? CockpitConnectionSettingsOverrides.settings(from: ProcessInfo.processInfo.arguments))
+            ?? (try? store.load())
+            ?? Self.defaultSettings
     }
 }

--- a/apps/apple/App/Info.plist
+++ b/apps/apple/App/Info.plist
@@ -33,6 +33,13 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Code Everywhere connects to your local Every Code broker.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/apps/apple/Sources/CodeEverywhereAppleCore/CockpitConnectionSettings.swift
+++ b/apps/apple/Sources/CodeEverywhereAppleCore/CockpitConnectionSettings.swift
@@ -12,6 +12,88 @@ public struct CockpitConnectionSettings: Equatable, Sendable {
     }
 }
 
+public enum CockpitConnectionSettingsDraftError: Error, Equatable {
+    case invalidCockpitURL
+    case invalidBrokerURL
+}
+
+public struct CockpitConnectionSettingsDraft: Equatable, Sendable {
+    public var cockpitURLText: String
+    public var brokerURLText: String
+    public var brokerAuthTokenText: String
+
+    public init(cockpitURLText: String, brokerURLText: String = "", brokerAuthTokenText: String = "") {
+        self.cockpitURLText = cockpitURLText
+        self.brokerURLText = brokerURLText
+        self.brokerAuthTokenText = brokerAuthTokenText
+    }
+
+    public init(settings: CockpitConnectionSettings) {
+        self.init(
+            cockpitURLText: settings.cockpitURL.absoluteString,
+            brokerURLText: settings.brokerURL?.absoluteString ?? "",
+            brokerAuthTokenText: settings.brokerAuthToken ?? "",
+        )
+    }
+
+    public func connectionSettings() throws -> CockpitConnectionSettings {
+        guard let cockpitURL = validatedURL(cockpitURLText) else {
+            throw CockpitConnectionSettingsDraftError.invalidCockpitURL
+        }
+
+        let brokerURL: URL?
+        if let brokerURLText = brokerURLText.nilIfBlank {
+            guard let parsedBrokerURL = validatedURL(brokerURLText) else {
+                throw CockpitConnectionSettingsDraftError.invalidBrokerURL
+            }
+            brokerURL = parsedBrokerURL
+        } else {
+            brokerURL = nil
+        }
+
+        return CockpitConnectionSettings(
+            cockpitURL: cockpitURL,
+            brokerURL: brokerURL,
+            brokerAuthToken: brokerAuthTokenText
+        )
+    }
+
+    private func validatedURL(_ value: String) -> URL? {
+        guard let text = value.nilIfBlank, let url = URL(string: text), url.host() != nil else {
+            return nil
+        }
+
+        switch url.scheme?.lowercased() {
+        case "http", "https":
+            return url
+        default:
+            return nil
+        }
+    }
+}
+
+public enum CockpitConnectionSettingsOverrides {
+    public static func settings(from arguments: [String]) throws -> CockpitConnectionSettings? {
+        guard arguments.contains("--code-everywhere-connection") else {
+            return nil
+        }
+
+        return try CockpitConnectionSettingsDraft(
+            cockpitURLText: optionValue(after: "--cockpit-url", in: arguments) ?? "",
+            brokerURLText: optionValue(after: "--broker-url", in: arguments) ?? "",
+            brokerAuthTokenText: optionValue(after: "--broker-auth-token", in: arguments) ?? ""
+        ).connectionSettings()
+    }
+
+    private static func optionValue(after option: String, in arguments: [String]) -> String? {
+        guard let index = arguments.firstIndex(of: option), arguments.indices.contains(index + 1) else {
+            return nil
+        }
+
+        return arguments[index + 1]
+    }
+}
+
 public struct CockpitConnectionSettingsStore {
     private let defaults: UserDefaults
     private let secrets: SecretStore

--- a/apps/apple/Sources/CodeEverywhereAppleUI/AppleConnectionSettingsPanel.swift
+++ b/apps/apple/Sources/CodeEverywhereAppleUI/AppleConnectionSettingsPanel.swift
@@ -1,0 +1,149 @@
+import CodeEverywhereAppleCore
+import SwiftUI
+
+public struct AppleConnectionSettingsPanel: View {
+    @Binding private var settings: CockpitConnectionSettings
+    private let store: CockpitConnectionSettingsStore
+
+    @State private var draft: CockpitConnectionSettingsDraft
+    @State private var isExpanded = false
+    @State private var statusMessage = "Connection settings loaded."
+    @State private var statusTone = AppleConnectionSettingsStatusTone.ready
+
+    public init(settings: Binding<CockpitConnectionSettings>, store: CockpitConnectionSettingsStore) {
+        _settings = settings
+        self.store = store
+        _draft = State(initialValue: CockpitConnectionSettingsDraft(settings: settings.wrappedValue))
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: 12) {
+                    statusLabel
+                    Spacer(minLength: 8)
+                    toggleButton
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    statusLabel
+                    toggleButton
+                }
+            }
+
+            if isExpanded {
+                VStack(alignment: .leading, spacing: 8) {
+                    TextField("Cockpit URL", text: $draft.cockpitURLText)
+#if os(iOS)
+                        .keyboardType(.URL)
+#endif
+                    TextField("Broker URL", text: $draft.brokerURLText)
+#if os(iOS)
+                        .keyboardType(.URL)
+#endif
+                    SecureField("Broker token", text: $draft.brokerAuthTokenText)
+                    HStack(spacing: 8) {
+                        Button {
+                            saveDraft()
+                        } label: {
+                            Label("Save", systemImage: "checkmark.circle")
+                        }
+
+                        Button {
+                            resetDraft()
+                        } label: {
+                            Label("Reset", systemImage: "arrow.counterclockwise")
+                        }
+                    }
+                }
+                .textFieldStyle(.roundedBorder)
+            }
+        }
+        .buttonStyle(.bordered)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Color.secondary.opacity(0.08))
+        .onChange(of: settings) { _, newSettings in
+            draft = CockpitConnectionSettingsDraft(settings: newSettings)
+        }
+    }
+
+    private var statusLabel: some View {
+        Label {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Connection")
+                    .font(.caption.weight(.semibold))
+                Text(statusMessage)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        } icon: {
+            Image(systemName: statusTone.systemImage)
+                .foregroundStyle(statusTone.tint)
+        }
+        .labelStyle(.titleAndIcon)
+    }
+
+    private var toggleButton: some View {
+        Button {
+            isExpanded.toggle()
+        } label: {
+            Label(isExpanded ? "Hide" : "Configure", systemImage: isExpanded ? "chevron.up" : "slider.horizontal.3")
+        }
+    }
+
+    private func saveDraft() {
+        do {
+            let nextSettings = try draft.connectionSettings()
+            try store.save(nextSettings)
+            settings = nextSettings
+            statusTone = .ready
+            statusMessage = "Saved \(nextSettings.cockpitURL.absoluteString)"
+        } catch {
+            statusTone = .error
+            statusMessage = message(for: error)
+        }
+    }
+
+    private func resetDraft() {
+        draft = CockpitConnectionSettingsDraft(settings: settings)
+        statusTone = .ready
+        statusMessage = "Connection settings restored."
+    }
+
+    private func message(for error: Error) -> String {
+        guard let draftError = error as? CockpitConnectionSettingsDraftError else {
+            return "Unable to save connection settings."
+        }
+
+        switch draftError {
+        case .invalidCockpitURL:
+            return "Enter a valid HTTP cockpit URL."
+        case .invalidBrokerURL:
+            return "Enter a valid HTTP broker URL or leave it blank."
+        }
+    }
+}
+
+private enum AppleConnectionSettingsStatusTone {
+    case ready
+    case error
+
+    var systemImage: String {
+        switch self {
+        case .ready:
+            return "network"
+        case .error:
+            return "exclamationmark.triangle"
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .ready:
+            return .secondary
+        case .error:
+            return .orange
+        }
+    }
+}

--- a/apps/apple/Sources/CodeEverywhereAppleUI/CockpitWebShell.swift
+++ b/apps/apple/Sources/CodeEverywhereAppleUI/CockpitWebShell.swift
@@ -3,21 +3,30 @@ import SwiftUI
 import WebKit
 
 public struct CockpitWebShell: View {
-    private let settings: CockpitConnectionSettings
+    @Binding private var settings: CockpitConnectionSettings
+    private let settingsStore: CockpitConnectionSettingsStore
     private let deepLinkRoute: CockpitDeepLinkRoute?
 
-    public init(settings: CockpitConnectionSettings, deepLinkRoute: CockpitDeepLinkRoute? = nil) {
-        self.settings = settings
+    public init(
+        settings: Binding<CockpitConnectionSettings>,
+        settingsStore: CockpitConnectionSettingsStore,
+        deepLinkRoute: CockpitDeepLinkRoute? = nil
+    ) {
+        _settings = settings
+        self.settingsStore = settingsStore
         self.deepLinkRoute = deepLinkRoute
     }
 
     public var body: some View {
         VStack(spacing: 0) {
+            AppleConnectionSettingsPanel(settings: $settings, store: settingsStore)
             AppleDeviceTrustRegistrationPanel(settings: settings)
             AppleNotificationReadinessPanel()
             ApplePendingWorkNotificationSyncTask(settings: settings)
             Divider()
             CockpitWebView(url: shellURL)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .layoutPriority(1)
         }
         .navigationTitle("Code Everywhere")
     }
@@ -41,12 +50,16 @@ public struct CockpitWebView: NSViewRepresentable {
         self.url = url
     }
 
-    public func makeNSView(context _: Context) -> WKWebView {
-        makeWebView(url: url)
+    public func makeCoordinator() -> CockpitWebViewCoordinator {
+        CockpitWebViewCoordinator()
     }
 
-    public func updateNSView(_ webView: WKWebView, context _: Context) {
-        loadIfNeeded(webView, url: url)
+    public func makeNSView(context: Context) -> WKWebView {
+        makeWebView(url: url, coordinator: context.coordinator)
+    }
+
+    public func updateNSView(_ webView: WKWebView, context: Context) {
+        loadIfNeeded(webView, url: url, coordinator: context.coordinator)
     }
 }
 #elseif os(iOS)
@@ -57,30 +70,55 @@ public struct CockpitWebView: UIViewRepresentable {
         self.url = url
     }
 
-    public func makeUIView(context _: Context) -> WKWebView {
-        makeWebView(url: url)
+    public func makeCoordinator() -> CockpitWebViewCoordinator {
+        CockpitWebViewCoordinator()
     }
 
-    public func updateUIView(_ webView: WKWebView, context _: Context) {
-        loadIfNeeded(webView, url: url)
+    public func makeUIView(context: Context) -> WKWebView {
+        makeWebView(url: url, coordinator: context.coordinator)
+    }
+
+    public func updateUIView(_ webView: WKWebView, context: Context) {
+        loadIfNeeded(webView, url: url, coordinator: context.coordinator)
     }
 }
 #endif
 
+public final class CockpitWebViewCoordinator: NSObject, WKNavigationDelegate {
+    fileprivate var requestedURL: URL?
+
+    public func webView(_ webView: WKWebView, didFinish _: WKNavigation!) {
+        guard let url = webView.url else {
+            return
+        }
+
+        requestedURL = url
+    }
+
+    public func webView(_: WKWebView, didFail _: WKNavigation!, withError _: Error) {
+        requestedURL = nil
+    }
+
+    public func webView(_: WKWebView, didFailProvisionalNavigation _: WKNavigation!, withError _: Error) {
+        requestedURL = nil
+    }
+}
+
 @MainActor
-private func makeWebView(url: URL) -> WKWebView {
+private func makeWebView(url: URL, coordinator: CockpitWebViewCoordinator) -> WKWebView {
     let configuration = WKWebViewConfiguration()
     configuration.defaultWebpagePreferences.allowsContentJavaScript = true
     let webView = WKWebView(frame: .zero, configuration: configuration)
-    webView.load(URLRequest(url: url))
+    webView.navigationDelegate = coordinator
     return webView
 }
 
 @MainActor
-private func loadIfNeeded(_ webView: WKWebView, url: URL) {
-    guard webView.url != url else {
+private func loadIfNeeded(_ webView: WKWebView, url: URL, coordinator: CockpitWebViewCoordinator) {
+    guard webView.url != url && coordinator.requestedURL != url else {
         return
     }
 
+    coordinator.requestedURL = url
     webView.load(URLRequest(url: url))
 }

--- a/apps/apple/Tests/CodeEverywhereAppleCoreTests/CockpitConnectionSettingsTests.swift
+++ b/apps/apple/Tests/CodeEverywhereAppleCoreTests/CockpitConnectionSettingsTests.swift
@@ -42,6 +42,82 @@ struct CockpitConnectionSettingsTests {
         #expect(try store.load() == nil)
     }
 
+    @Test("creates settings from editable URL text")
+    func createsSettingsFromDraftText() throws {
+        let draft = CockpitConnectionSettingsDraft(
+            cockpitURLText: " http://127.0.0.1:5180 ",
+            brokerURLText: " http://127.0.0.1:4789 ",
+            brokerAuthTokenText: " secret-token "
+        )
+
+        #expect(try draft.connectionSettings() == CockpitConnectionSettings(
+            cockpitURL: URL(string: "http://127.0.0.1:5180")!,
+            brokerURL: URL(string: "http://127.0.0.1:4789")!,
+            brokerAuthToken: "secret-token"
+        ))
+    }
+
+    @Test("allows a blank broker URL but requires a valid cockpit URL")
+    func validatesDraftURLs() throws {
+        #expect(try CockpitConnectionSettingsDraft(
+            cockpitURLText: "https://code-everywhere.local",
+            brokerURLText: ""
+        ).connectionSettings() == CockpitConnectionSettings(
+            cockpitURL: URL(string: "https://code-everywhere.local")!,
+            brokerURL: nil
+        ))
+        #expect(throws: CockpitConnectionSettingsDraftError.invalidCockpitURL) {
+            try CockpitConnectionSettingsDraft(cockpitURLText: "not a url").connectionSettings()
+        }
+        #expect(throws: CockpitConnectionSettingsDraftError.invalidBrokerURL) {
+            try CockpitConnectionSettingsDraft(
+                cockpitURLText: "http://127.0.0.1:5180",
+                brokerURLText: "file:///tmp/broker"
+            ).connectionSettings()
+        }
+    }
+
+    @Test("creates settings from launch arguments")
+    func createsSettingsFromLaunchArguments() throws {
+        #expect(try CockpitConnectionSettingsOverrides.settings(from: ["CodeEverywhere"]) == nil)
+        #expect(try CockpitConnectionSettingsOverrides.settings(from: [
+            "CodeEverywhere",
+            "--code-everywhere-connection",
+            "--cockpit-url",
+            "http://192.168.1.3:5181",
+            "--broker-url",
+            "http://192.168.1.3:4790",
+            "--broker-auth-token",
+            " proof-token ",
+        ]) == CockpitConnectionSettings(
+            cockpitURL: URL(string: "http://192.168.1.3:5181")!,
+            brokerURL: URL(string: "http://192.168.1.3:4790")!,
+            brokerAuthToken: "proof-token"
+        ))
+    }
+
+    @Test("rejects malformed launch argument overrides")
+    func rejectsMalformedLaunchArgumentOverrides() throws {
+        #expect(throws: CockpitConnectionSettingsDraftError.invalidCockpitURL) {
+            try CockpitConnectionSettingsOverrides.settings(from: [
+                "CodeEverywhere",
+                "--code-everywhere-connection",
+                "--broker-url",
+                "http://192.168.1.3:4790",
+            ])
+        }
+        #expect(throws: CockpitConnectionSettingsDraftError.invalidBrokerURL) {
+            try CockpitConnectionSettingsOverrides.settings(from: [
+                "CodeEverywhere",
+                "--code-everywhere-connection",
+                "--cockpit-url",
+                "http://192.168.1.3:5182",
+                "--broker-url",
+                "ftp://192.168.1.3:4790",
+            ])
+        }
+    }
+
     private func makeDefaults() -> UserDefaults {
         let suiteName = "CodeEverywhereAppleTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName) ?? .standard

--- a/apps/apple/project.yml
+++ b/apps/apple/project.yml
@@ -36,6 +36,10 @@ targets:
                       CFBundleURLSchemes:
                           - code-everywhere
                 LSRequiresIPhoneOS: true
+                NSAppTransportSecurity:
+                    NSAllowsLocalNetworking: true
+                NSLocalNetworkUsageDescription: >-
+                    Code Everywhere connects to your local Every Code broker.
                 UIApplicationSceneManifest:
                     UIApplicationSupportsMultipleScenes: true
                 UIApplicationSupportsIndirectInputEvents: true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -105,6 +105,12 @@ and simulator-buildable with `CODE_SIGNING_ALLOWED=NO`. It launches the shared
 cockpit web-view shell and consumes the package-owned connection settings,
 Keychain-backed token storage, and deep-link parsing.
 
+The Apple shell exposes those connection settings in native UI so a simulator or
+device can point at a local, LAN, or hosted cockpit/broker pair without editing
+source or committing generated project files. Broker auth tokens remain in
+Keychain; public cockpit and broker URLs remain in user defaults. Local HTTP and
+LAN proof runs require the app target's local-network transport permissions.
+
 Notification routing starts in Apple core as route metadata, not APNs delivery.
 Native notification payloads should carry a `code-everywhere://` route URL that
 round-trips through the same session and pending-item parser used by the app


### PR DESCRIPTION
## Summary
- add a native Apple connection settings panel for cockpit URL, broker URL, and broker token
- persist public URLs in user defaults and broker auth tokens in Keychain-backed storage
- add launch-argument overrides for deterministic simulator proof runs
- keep generated Xcode project output derived from `apps/apple/project.yml`, including local-network plist keys
- document the Apple shell connection flow and local/LAN proof caveat

## Validation
- `pnpm apple:build && pnpm apple:test && pnpm apple:app:build && pnpm lint:dry-run && pnpm validate && pnpm smoke:cockpit:web && git diff --check`
- Apple tests: 37 tests in 7 suites passed
- Web smoke: cockpit web live-loop passed at `http://127.0.0.1:52405` using broker `http://127.0.0.1:52404`
- WebStorm changed-files inspection: no code findings; only grammar/typo proofreading noise, including expected Swift/plist terms (`exclamationmark`, `fileprivate`, `APPL`)

## Manual Proof
- launched iOS simulator app against production-preview cockpit `http://192.168.1.3:5182` and broker `http://192.168.1.3:4790`
- captured Apple shell screenshot at `scratch/ui-checks/apple-webview-current-branch.png`
- proof broker snapshot was healthy but empty: `sessions: 0`, `pendingApprovals: 0`, `requestedInputs: 0`

## Notes
- The generated `apps/apple/CodeEverywhereApple.xcodeproj` remains gitignored; `project.yml` is the source of truth.
- Embedded `WKWebView` proof is reliable against a built/previewed web cockpit. The Vite dev-server path showed blank/reload behavior during exploration and should be investigated separately if we want live dev-server embedding.
